### PR TITLE
V8

### DIFF
--- a/docs/notebooks/introduction.ipynb
+++ b/docs/notebooks/introduction.ipynb
@@ -332,17 +332,17 @@
       "provenance": []
     },
     "kernelspec": {
-      "display_name": "Python 3.8.9 64-bit",
+      "display_name": "Python 3.10.5 ('dev-jax')",
       "language": "python",
       "name": "python3"
     },
     "language_info": {
       "name": "python",
-      "version": "3.8.9"
+      "version": "3.10.5"
     },
     "vscode": {
       "interpreter": {
-        "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+        "hash": "4dbabdc3ed9c56a6e246ce2e910e119890ccd2806df70655d281d35df3853255"
       }
     }
   },

--- a/pytreeclass/src/decorator.py
+++ b/pytreeclass/src/decorator.py
@@ -14,7 +14,7 @@ from .tree_op_base import treeOpBase
 def treeclass(*args, **kwargs):
     """Class JAX  compaitable decorator for `dataclass`"""
 
-    def wrapper(cls, op: bool, field_only: bool):
+    def wrapper(cls, field_only: bool):
         user_defined_init = "__init__" in cls.__dict__
 
         dCls = dataclass(
@@ -31,7 +31,7 @@ def treeclass(*args, **kwargs):
         return jax.tree_util.register_pytree_node_class(new_cls)
 
     if len(args) == 1 and inspect.isclass(args[0]):
-        return wrapper(args[0], True, False)
+        return wrapper(args[0], False)
 
     elif len(args) == 0 and len(kwargs) > 0:
         field_only = kwargs["field_only"] if "field_only" in kwargs else False

--- a/pytreeclass/src/decorator.py
+++ b/pytreeclass/src/decorator.py
@@ -23,18 +23,16 @@ def treeclass(*args, **kwargs):
 
         base_classes = (dCls, treeBase)
 
-        if op:
-            base_classes += (treeOpBase, treeIndexer)
-            base_classes += (explicitTreeBase,) if field_only else (implicitTreeBase,)
+        base_classes += (treeOpBase, treeIndexer)
+        base_classes += (explicitTreeBase,) if field_only else (implicitTreeBase,)
 
-        newCls = type(cls.__name__, base_classes, {})
+        new_cls = type(cls.__name__, base_classes, {})
 
-        return jax.tree_util.register_pytree_node_class(newCls)
+        return jax.tree_util.register_pytree_node_class(new_cls)
 
     if len(args) == 1 and inspect.isclass(args[0]):
         return wrapper(args[0], True, False)
 
     elif len(args) == 0 and len(kwargs) > 0:
-        op = kwargs["op"] if "op" in kwargs else True
         field_only = kwargs["field_only"] if "field_only" in kwargs else False
-        return functools.partial(wrapper, op=op, field_only=field_only)
+        return functools.partial(wrapper, field_only=field_only)

--- a/pytreeclass/src/tree_base.py
+++ b/pytreeclass/src/tree_base.py
@@ -4,7 +4,7 @@ import copy
 from dataclasses import MISSING, field
 from typing import Any
 
-from jax.tree_util import tree_leaves
+import jax.tree_util as jtu
 
 from .tree_util import _freeze_nodes, _unfreeze_nodes, is_treeclass, is_treeclass_leaf
 from .tree_viz import summary, tree_box, tree_diagram, tree_indent, tree_str
@@ -174,7 +174,7 @@ class treeBase:
     @property
     def treeclass_leaves(self):
         """Tree leaves of treeclass"""
-        return tree_leaves(self, is_treeclass_leaf)
+        return jtu.tree_leaves(self, is_treeclass_leaf)
 
     def __hash__(self):
         return hash(tuple(*self.flatten_leaves))

--- a/pytreeclass/src/tree_indexer.py
+++ b/pytreeclass/src/tree_indexer.py
@@ -1,51 +1,20 @@
 from __future__ import annotations
 
-import copy
 from collections.abc import Callable
 from typing import Any
 
 import jax.numpy as jnp
-from jax.tree_util import tree_flatten, tree_leaves, tree_map, tree_unflatten
+import jax.tree_util as jtu
 
 import pytreeclass
 from pytreeclass.src.decorator_util import dispatch
 from pytreeclass.src.tree_util import is_treeclass_leaf_bool
 
-
-@dispatch(argnum=0)
-def _node_setter(lhs: Any, where: bool, set_value):
-    """Set pytree node value.
-
-    Args:
-        lhs: Node value.
-        where: Conditional.
-        set_value: Set value of shape 1.
-
-    Returns:
-        Modified node value.
-    """
-    raise NotImplementedError("lhs type is unknown.")
-
-
-@_node_setter.register(jnp.ndarray)
-def _(lhs, where, set_value):
-    return jnp.where(where, set_value, lhs)
-
-
-@_node_setter.register(pytreeclass.src.tree_base.treeBase)
-def _(lhs, where, set_value):
-    return tree_map(lambda x: _node_setter(x, where, set_value), lhs)
-
-
-@_node_setter.register(int)
-@_node_setter.register(float)
-@_node_setter.register(complex)
-def _(lhs, where, set_value):
-    return set_value if where else lhs
+""" Getter """
 
 
 @dispatch(argnum=0)
-def _node_at_getter(lhs: Any, where: Any):
+def _node_get(lhs: Any, where: Any, *args, **kwargs):
     """Get pytree node  value
 
     Args:
@@ -60,26 +29,106 @@ def _node_at_getter(lhs: Any, where: Any):
     raise NotImplementedError(f"lhs type ={type(lhs)} is not implemented.")
 
 
-@_node_at_getter.register(jnp.ndarray)
-def _(lhs, where):
-    return lhs[jnp.where(where)]
+@_node_get.register(jnp.ndarray)
+def _(lhs, where, array_as_leaves: bool = True):
+    return (
+        (lhs[jnp.where(where)])
+        if array_as_leaves
+        else (lhs if jnp.all(where) else None)
+    )
 
 
-@_node_at_getter.register(pytreeclass.src.tree_base.treeBase)
-def _(lhs, where):
-    return tree_map(lambda x: _node_at_getter(x, where), lhs)
+@_node_get.register(pytreeclass.src.tree_base.treeBase)
+def _(lhs, where, *args, **kwargs):
+    return jtu.tree_map(lambda x: _node_get(x, where), lhs, *args, **kwargs)
 
 
-@_node_at_getter.register(int)
-@_node_at_getter.register(float)
-@_node_at_getter.register(complex)
-def _(lhs, where):
+@_node_get.register(int)
+@_node_get.register(float)
+@_node_get.register(complex)
+def _(lhs, where, *args, **kwargs):
     # set None to non-chosen non-array values
     return lhs if where else None
 
 
+@dispatch(argnum=1)
+def _at_get(model, where, *args, **kwargs):
+    raise NotImplementedError(f"Where type = {type(where)} is not implemented.")
+
+
+@_at_get.register(pytreeclass.src.tree_base.treeBase)
+def _(model, where, *args, **kwargs):
+    lhs_leaves, lhs_treedef = jtu.tree_flatten(model)
+    where_leaves, where_treedef = jtu.tree_flatten(where)
+    lhs_leaves = [
+        _node_get(lhs_leaf, where_leaf, *args, **kwargs)
+        for lhs_leaf, where_leaf in zip(lhs_leaves, where_leaves)
+    ]
+
+    return jtu.tree_unflatten(lhs_treedef, lhs_leaves)
+
+
+""" Setter """
+
+
 @dispatch(argnum=0)
-def _node_applier(lhs: Any, where: bool, func: Callable[[Any], Any]):
+def _node_set(lhs: Any, where: bool, set_value, *args, **kwargs):
+    """Set pytree node value.
+
+    Args:
+        lhs: Node value.
+        where: Conditional.
+        set_value: Set value of shape 1.
+
+    Returns:
+        Modified node value.
+    """
+    raise NotImplementedError("lhs type is unknown.")
+
+
+@_node_set.register(jnp.ndarray)
+def _(lhs, where, set_value, array_as_leaves: bool = True):
+    return (
+        jnp.where(where, set_value, lhs)
+        if array_as_leaves
+        else (set_value if jnp.all(where) else lhs)
+    )
+
+
+@_node_set.register(pytreeclass.src.tree_base.treeBase)
+def _(lhs, where, set_value, *args, **kwargs):
+    return jtu.tree_map(lambda x: _node_set(x, where, set_value, *args, **kwargs), lhs)
+
+
+@_node_set.register(int)
+@_node_set.register(float)
+@_node_set.register(complex)
+def _(lhs, where, set_value, *args, **kwargs):
+    return set_value if where else lhs
+
+
+@dispatch(argnum=2)
+def _at_set(model, set_value, where, *args, **kwargs):
+    raise NotImplementedError(f"Where type = {type(where)} is not implemented.")
+
+
+@_at_set.register(pytreeclass.src.tree_base.treeBase)
+def _(model, set_value, where, *args, **kwargs):
+    lhs_leaves, lhs_treedef = jtu.tree_flatten(model)
+    where_leaves, rhs_treedef = jtu.tree_flatten(where)
+    lhs_leaves = [
+        _node_set(lhs_leaf, where_leaf, set_value, *args, **kwargs)
+        for lhs_leaf, where_leaf in zip(lhs_leaves, where_leaves)  # fmt: skip
+    ]
+
+    return jtu.tree_unflatten(lhs_treedef, lhs_leaves)
+
+
+""" Apply """
+
+
+@dispatch(argnum=0)
+def _node_apply(lhs: Any, where: bool, func: Callable[[Any], Any], *args, **kwargs):
     """Set pytree node
 
     Args:
@@ -93,126 +142,57 @@ def _node_applier(lhs: Any, where: bool, func: Callable[[Any], Any]):
     raise NotImplementedError(f"lhs type= {type(lhs)} is not implemented.")
 
 
-@_node_applier.register(jnp.ndarray)
-def _(lhs, where, func):
-    return jnp.where(where, func(lhs), lhs)
+@_node_apply.register(jnp.ndarray)
+def _(lhs, where, func, array_as_leaves: bool = True):
+    return (
+        jnp.where(where, func(lhs), lhs)
+        if array_as_leaves
+        else (func(lhs) if jnp.all(where) else lhs)
+    )
 
 
-@_node_applier.register(pytreeclass.src.tree_base.treeBase)
-def _(lhs, where, func):
-    return tree_map(lambda x: _node_applier(x, where, func), lhs)
+@_node_apply.register(pytreeclass.src.tree_base.treeBase)
+def _(lhs, where, func, *args, **kwargs):
+    return jtu.tree_map(lambda x: _node_apply(x, where, func, *args, **kwargs), lhs)
 
 
-@_node_applier.register(int)
-@_node_applier.register(float)
-@_node_applier.register(complex)
-def _(lhs, where, func):
+@_node_apply.register(int)
+@_node_apply.register(float)
+@_node_apply.register(complex)
+def _(lhs, where, func, *args, **kwargs):
     return func(lhs) if where else lhs
 
 
-@dispatch(argnum=1)
-def _at_getter(model, where):
+@dispatch(argnum=2)
+def _at_apply(model, set_value, where, *args, **kwargs):
     raise NotImplementedError(f"Where type = {type(where)} is not implemented.")
 
 
-@_at_getter.register(int)
-@_at_getter.register(str)
-@_at_getter.register(tuple)
-def _(model, *where):
-    modelCopy = copy.copy(model)
-
-    for i, field in enumerate(model.__dataclass_fields__.values()):
-        value = modelCopy.__dict__[field.name]
-        excluded_by_type = isinstance(value, str)
-        excluded_by_meta = ("static" in field.metadata) and field.metadata["static"] is True  # fmt: skip
-        excluded = excluded_by_type or excluded_by_meta
-
-        if not excluded and not (i in where or field.name in where):
-            modelCopy.__dict__[field.name] = _node_at_getter(value, False)
-
-    return modelCopy
-
-
-@_at_getter.register(pytreeclass.src.tree_base.treeBase)
-def _(model, where):
-    lhs_leaves, lhs_treedef = tree_flatten(model)
-    where_leaves, where_treedef = tree_flatten(where)
+@_at_apply.register(pytreeclass.src.tree_base.treeBase)
+def _(model, func, where, *args, **kwargs):
+    lhs_leaves, lhs_treedef = jtu.tree_flatten(model)
+    where_leaves, rhs_treedef = jtu.tree_flatten(where)
     lhs_leaves = [
-        _node_at_getter(lhs_leaf, where_leaf)
+        _node_apply(lhs_leaf, where_leaf, func, *args, **kwargs)
         for lhs_leaf, where_leaf in zip(lhs_leaves, where_leaves)
     ]
 
-    return tree_unflatten(lhs_treedef, lhs_leaves)
+    return jtu.tree_unflatten(lhs_treedef, lhs_leaves)
+
+
+""" Reduce apply """
 
 
 @dispatch(argnum=2)
-def _at_setter(model, set_value, where):
+def _at_reduce_apply(model, set_value, where, *args, **kwargs):
     raise NotImplementedError(f"Where type = {type(where)} is not implemented.")
 
 
-@_at_setter.register(int)
-@_at_setter.register(str)
-@_at_setter.register(tuple)
-def _(model, set_value, *where: tuple[str | int, ...]):
-    modelCopy = copy.copy(model)
-
-    for i, field in enumerate(model.__dataclass_fields__.values()):
-        value = modelCopy.__dict__[field.name]
-        excluded_by_type = isinstance(value, str)
-        excluded_by_meta = ("static" in field.metadata) and field.metadata["static"] is True  # fmt: skip
-        excluded = excluded_by_type or excluded_by_meta
-
-        if not excluded and (i in where or field.name in where):
-            modelCopy.__dict__[field.name] = _node_setter(value, True, set_value)
-
-    return modelCopy
-
-
-@_at_setter.register(pytreeclass.src.tree_base.treeBase)
-def _(model, set_value, where):
-    lhs_leaves, lhs_treedef = tree_flatten(model)
-    where_leaves, rhs_treedef = tree_flatten(where)
-    lhs_leaves = [
-        _node_setter(lhs_leaf, where_leaf, set_value,)
-        for lhs_leaf, where_leaf in zip(lhs_leaves, where_leaves)  # fmt: skip
-    ]
-
-    return tree_unflatten(lhs_treedef, lhs_leaves)
-
-
-@dispatch(argnum=2)
-def _at_applier(model, set_value, where):
-    raise NotImplementedError(f"Where type = {type(where)} is not implemented.")
-
-
-@_at_applier.register(int)
-@_at_applier.register(str)
-@_at_applier.register(tuple)
-def _(model, set_value, *where):
-    modelCopy = copy.copy(model)
-
-    for i, field in enumerate(model.__dataclass_fields__.values()):
-        value = modelCopy.__dict__[field.name]
-        excluded_by_type = isinstance(value, str)
-        excluded_by_meta = ("static" in field.metadata) and field.metadata["static"] is True  # fmt: skip
-        excluded = excluded_by_type or excluded_by_meta
-
-        if not excluded and (i in where or field.name in where):
-            modelCopy.__dict__[field.name] = _node_applier(value, True, set_value)
-
-    return modelCopy
-
-
-@_at_applier.register(pytreeclass.src.tree_base.treeBase)
-def _(model, func, where):
-    lhs_leaves, lhs_treedef = tree_flatten(model)
-    where_leaves, rhs_treedef = tree_flatten(where)
-    lhs_leaves = [
-        _node_applier(lhs_leaf, where_leaf, func=func)
-        for lhs_leaf, where_leaf in zip(lhs_leaves, where_leaves)  # fmt: skip
-    ]
-
-    return tree_unflatten(lhs_treedef, lhs_leaves)
+@_at_reduce_apply.register(pytreeclass.src.tree_base.treeBase)
+def _(tree, func, where, reduce_op=jnp.add, **kwargs):
+    mask = tree.at[where].get()
+    mask = mask.at[mask == mask].apply(func, array_as_leaves=False)
+    return jtu.tree_reduce(lambda acc, cur: reduce_op(acc, cur), mask)
 
 
 class treeIndexerMethods:
@@ -245,65 +225,35 @@ class treeIndexer:
                     f"Indexing with type{tuple(type(arg) for arg in args)} is not implemented."
                 )
 
-            @__getitem__.register(int)
-            @__getitem__.register(str)
-            @__getitem__.register(tuple)
-            @__getitem__.register(range)
-            def _(inner_self, *args):
-                """Non-boolean indexing"""
-
-                # Normalize indices
-                flatten_args = [
-                    (arg + len(self.__dataclass_fields__) if arg < 0 else arg)
-                    if isinstance(arg, int)
-                    else arg
-                    for arg in tree_leaves(args)
-                ]
-
-                class getterSetterIndexer(treeIndexerMethods):
-                    def get(getter_setter_self):
-                        return _at_getter(self, *flatten_args)
-
-                    def set(getter_setter_self, set_value):
-                        if self.frozen:
-                            raise ValueError("Cannot set to a frozen treeclass.")
-                        return _at_setter(self, set_value, *flatten_args)
-
-                    def apply(getter_setter_self, func):
-                        if self.frozen:
-                            raise ValueError("Cannot apply to a frozen treeclass.")
-                        return _at_applier(self, func, *flatten_args)
-
-                return getterSetterIndexer()
-
             @__getitem__.register(type(self))
             def _(inner_self, arg):
                 """indexing by boolean pytree"""
 
-                if not all(is_treeclass_leaf_bool(leaf) for leaf in tree_leaves(arg)):
+                if not all(
+                    is_treeclass_leaf_bool(leaf) for leaf in jtu.tree_leaves(arg)
+                ):
                     raise ValueError("All model leaves must be boolean.")
 
                 class getterSetterIndexer(treeIndexerMethods):
-                    def get(getter_setter_self):
-                        return _at_getter(self, arg)
+                    def get(getter_setter_self, **kwargs):
+                        return _at_get(self, arg, **kwargs)
 
-                    def set(getter_setter_self, set_value):
+                    def set(getter_setter_self, set_value, **kwargs):
                         if self.frozen:
                             raise ValueError("Cannot set to a frozen treeclass.")
-                        return _at_setter(self, set_value, arg)
+                        return _at_set(self, set_value, arg, **kwargs)
 
-                    def apply(getter_setter_self, func):
+                    def apply(getter_setter_self, func, **kwargs):
                         if self.frozen:
                             raise ValueError("Cannot apply to a frozen treeclass.")
-                        return _at_applier(self, func, arg)
+                        return _at_apply(self, func, arg, **kwargs)
+
+                    def reduce_apply(getter_setter_self, func, **kwargs):
+                        if self.frozen:
+                            raise ValueError("Cannot apply to a frozen treeclass.")
+                        return _at_reduce_apply(self, func, arg, **kwargs)
 
                 return getterSetterIndexer()
-
-            @__getitem__.register(slice)
-            def _(inner_self, arg):
-                return inner_self.__getitem__(
-                    *range(*arg.indices(len(self.__dataclass_fields__)))
-                )
 
         return indexer()
 

--- a/pytreeclass/src/tree_indexer.py
+++ b/pytreeclass/src/tree_indexer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from collections.abc import Callable
 from typing import Any
 
@@ -7,14 +8,14 @@ import jax.numpy as jnp
 import jax.tree_util as jtu
 
 import pytreeclass
+import pytreeclass.src.tree_util as ptu
 from pytreeclass.src.decorator_util import dispatch
-from pytreeclass.src.tree_util import is_treeclass_leaf_bool
 
 """ Getter """
 
 
 @dispatch(argnum=0)
-def _node_get(lhs: Any, where: Any, *args, **kwargs):
+def _node_get(lhs: Any, where: Any, **kwargs):
     """Get pytree node  value
 
     Args:
@@ -39,40 +40,59 @@ def _(lhs, where, array_as_leaves: bool = True):
 
 
 @_node_get.register(pytreeclass.src.tree_base.treeBase)
-def _(lhs, where, *args, **kwargs):
-    return jtu.tree_map(lambda x: _node_get(x, where), lhs, *args, **kwargs)
+def _(lhs, where, **kwargs):
+    return jtu.tree_map(lambda x: _node_get(x, where), lhs, **kwargs)
 
 
 @_node_get.register(int)
 @_node_get.register(float)
 @_node_get.register(complex)
-def _(lhs, where, *args, **kwargs):
+@_node_get.register(tuple)
+@_node_get.register(list)
+def _(lhs, where, **kwargs):
     # set None to non-chosen non-array values
     return lhs if where else None
 
 
 @dispatch(argnum=1)
-def _at_get(model, where, *args, **kwargs):
+def _at_get(tree, where, **kwargs):
     raise NotImplementedError(f"Where type = {type(where)} is not implemented.")
 
 
 @_at_get.register(pytreeclass.src.tree_base.treeBase)
-def _(model, where, *args, **kwargs):
-    lhs_leaves, lhs_treedef = jtu.tree_flatten(model)
+def _(tree, where, **kwargs):
+    lhs_leaves, lhs_treedef = jtu.tree_flatten(tree)
     where_leaves, where_treedef = jtu.tree_flatten(where)
     lhs_leaves = [
-        _node_get(lhs_leaf, where_leaf, *args, **kwargs)
+        _node_get(lhs_leaf, where_leaf, **kwargs)
         for lhs_leaf, where_leaf in zip(lhs_leaves, where_leaves)
     ]
 
     return jtu.tree_unflatten(lhs_treedef, lhs_leaves)
 
 
+@_at_get.register(str)
+@_at_get.register(tuple)
+def _(tree, *where, **kwargs):
+    tree_copy = copy.copy(tree)
+
+    for i, fld in enumerate(tree.__dataclass_fields__.values()):
+
+        if not ptu.is_excluded(fld, tree_copy) and not (
+            i in where or fld.name in where
+        ):
+            tree_copy.__dict__[fld.name] = _node_get(
+                tree_copy.__dict__[fld.name], False, **kwargs
+            )
+
+    return tree_copy
+
+
 """ Setter """
 
 
 @dispatch(argnum=0)
-def _node_set(lhs: Any, where: bool, set_value, *args, **kwargs):
+def _node_set(lhs: Any, where: bool, set_value, **kwargs):
     """Set pytree node value.
 
     Args:
@@ -83,52 +103,69 @@ def _node_set(lhs: Any, where: bool, set_value, *args, **kwargs):
     Returns:
         Modified node value.
     """
-    raise NotImplementedError("lhs type is unknown.")
+    raise NotImplementedError(f"lhs type = {type(lhs)} is unknown.")
 
 
 @_node_set.register(jnp.ndarray)
 def _(lhs, where, set_value, array_as_leaves: bool = True):
     return (
-        jnp.where(where, set_value, lhs)
+        jnp.where(where, set_value, lhs)  # JITable
         if array_as_leaves
-        else (set_value if jnp.all(where) else lhs)
+        else (set_value if jnp.all(where) else lhs)  # Not JITable
     )
 
 
 @_node_set.register(pytreeclass.src.tree_base.treeBase)
-def _(lhs, where, set_value, *args, **kwargs):
-    return jtu.tree_map(lambda x: _node_set(x, where, set_value, *args, **kwargs), lhs)
+def _(lhs, where, set_value, **kwargs):
+    return jtu.tree_map(lambda x: _node_set(x, where, set_value, **kwargs), lhs)
 
 
 @_node_set.register(int)
 @_node_set.register(float)
 @_node_set.register(complex)
-def _(lhs, where, set_value, *args, **kwargs):
+@_node_set.register(tuple)
+@_node_set.register(list)
+def _(lhs, where, set_value, **kwargs):
     return set_value if where else lhs
 
 
 @dispatch(argnum=2)
-def _at_set(model, set_value, where, *args, **kwargs):
+def _at_set(tree, set_value, where, **kwargs):
     raise NotImplementedError(f"Where type = {type(where)} is not implemented.")
 
 
 @_at_set.register(pytreeclass.src.tree_base.treeBase)
-def _(model, set_value, where, *args, **kwargs):
-    lhs_leaves, lhs_treedef = jtu.tree_flatten(model)
+def _(tree, set_value, where, **kwargs):
+    lhs_leaves, lhs_treedef = jtu.tree_flatten(tree)
     where_leaves, rhs_treedef = jtu.tree_flatten(where)
     lhs_leaves = [
-        _node_set(lhs_leaf, where_leaf, set_value, *args, **kwargs)
-        for lhs_leaf, where_leaf in zip(lhs_leaves, where_leaves)  # fmt: skip
+        _node_set(lhs_leaf, where_leaf, set_value, **kwargs)
+        for lhs_leaf, where_leaf in zip(lhs_leaves, where_leaves)
     ]
 
     return jtu.tree_unflatten(lhs_treedef, lhs_leaves)
+
+
+@_at_set.register(str)
+@_at_set.register(tuple)
+def _(tree, set_value, *where, **kwargs):
+    tree_copy = copy.copy(tree)
+
+    for i, fld in enumerate(tree.__dataclass_fields__.values()):
+
+        if not ptu.is_excluded(fld, tree_copy) and (i in where or fld.name in where):
+            tree_copy.__dict__[fld.name] = _node_set(
+                tree_copy.__dict__[fld.name], True, set_value, **kwargs
+            )
+
+    return tree_copy
 
 
 """ Apply """
 
 
 @dispatch(argnum=0)
-def _node_apply(lhs: Any, where: bool, func: Callable[[Any], Any], *args, **kwargs):
+def _node_apply(lhs: Any, where: bool, func: Callable[[Any], Any], **kwargs):
     """Set pytree node
 
     Args:
@@ -152,47 +189,62 @@ def _(lhs, where, func, array_as_leaves: bool = True):
 
 
 @_node_apply.register(pytreeclass.src.tree_base.treeBase)
-def _(lhs, where, func, *args, **kwargs):
-    return jtu.tree_map(lambda x: _node_apply(x, where, func, *args, **kwargs), lhs)
+def _(lhs, where, func, **kwargs):
+    return jtu.tree_map(lambda x: _node_apply(x, where, func, **kwargs), lhs)
 
 
 @_node_apply.register(int)
 @_node_apply.register(float)
 @_node_apply.register(complex)
-def _(lhs, where, func, *args, **kwargs):
+@_node_apply.register(tuple)
+@_node_apply.register(list)
+def _(lhs, where, func, **kwargs):
     return func(lhs) if where else lhs
 
 
 @dispatch(argnum=2)
-def _at_apply(model, set_value, where, *args, **kwargs):
+def _at_apply(tree, set_value, where, **kwargs):
     raise NotImplementedError(f"Where type = {type(where)} is not implemented.")
 
 
 @_at_apply.register(pytreeclass.src.tree_base.treeBase)
-def _(model, func, where, *args, **kwargs):
-    lhs_leaves, lhs_treedef = jtu.tree_flatten(model)
+def _(tree, func, where, **kwargs):
+    lhs_leaves, lhs_treedef = jtu.tree_flatten(tree)
     where_leaves, rhs_treedef = jtu.tree_flatten(where)
     lhs_leaves = [
-        _node_apply(lhs_leaf, where_leaf, func, *args, **kwargs)
+        _node_apply(lhs_leaf, where_leaf, func, **kwargs)
         for lhs_leaf, where_leaf in zip(lhs_leaves, where_leaves)
     ]
 
     return jtu.tree_unflatten(lhs_treedef, lhs_leaves)
 
 
-""" Reduce apply """
+@_at_apply.register(str)
+@_at_apply.register(tuple)
+def _(tree, func, *where, **kwargs):
+    tree_copy = copy.copy(tree)
+
+    for i, fld in enumerate(tree.__dataclass_fields__.values()):
+
+        if not ptu.is_excluded(fld, tree_copy) and (i in where or fld.name in where):
+            tree_copy.__dict__[fld.name] = _node_apply(
+                tree_copy.__dict__[fld.name], True, func, **kwargs
+            )
+
+    return tree_copy
+
+
+""" Reduce """
 
 
 @dispatch(argnum=2)
-def _at_reduce_apply(model, set_value, where, *args, **kwargs):
+def _at_reduce(tree, set_value, where, **kwargs):
     raise NotImplementedError(f"Where type = {type(where)} is not implemented.")
 
 
-@_at_reduce_apply.register(pytreeclass.src.tree_base.treeBase)
-def _(tree, func, where, reduce_op=jnp.add, **kwargs):
-    mask = tree.at[where].get()
-    mask = mask.at[mask == mask].apply(func, array_as_leaves=False)
-    return jtu.tree_reduce(lambda acc, cur: reduce_op(acc, cur), mask)
+@_at_reduce.register(pytreeclass.src.tree_base.treeBase)
+def _(tree, func, where, initializer=0, **kwargs):
+    return jtu.tree_reduce(func, tree.at[where].get(), initializer)
 
 
 class treeIndexerMethods:
@@ -214,6 +266,22 @@ class treeIndexerMethods:
     def max(getter_setter_self, set_value):
         return getter_setter_self.apply(lambda x: jnp.maximum(x, set_value))
 
+    def reduce_sum(getter_setter_self):
+        return getter_setter_self.reduce(lambda x, y: x + jnp.sum(y))
+
+    def reduce_product(getter_setter_self):
+        return getter_setter_self.reduce(lambda x, y: x * jnp.prod(y), 1)
+
+    def reduce_max(getter_setter_self):
+        return getter_setter_self.reduce(
+            lambda x, y: jnp.maximum(x, jnp.max(y)), initializer=-jnp.inf
+        )
+
+    def reduce_min(getter_setter_self):
+        return getter_setter_self.reduce(
+            lambda x, y: jnp.minimum(x, jnp.min(y)), initializer=+jnp.inf
+        )
+
 
 class treeIndexer:
     @property
@@ -230,9 +298,9 @@ class treeIndexer:
                 """indexing by boolean pytree"""
 
                 if not all(
-                    is_treeclass_leaf_bool(leaf) for leaf in jtu.tree_leaves(arg)
+                    ptu.is_treeclass_leaf_bool(leaf) for leaf in jtu.tree_leaves(arg)
                 ):
-                    raise ValueError("All model leaves must be boolean.")
+                    raise ValueError("All tree leaves must be of boolean type.")
 
                 class getterSetterIndexer(treeIndexerMethods):
                     def get(getter_setter_self, **kwargs):
@@ -248,10 +316,38 @@ class treeIndexer:
                             raise ValueError("Cannot apply to a frozen treeclass.")
                         return _at_apply(self, func, arg, **kwargs)
 
-                    def reduce_apply(getter_setter_self, func, **kwargs):
+                    def reduce(getter_setter_self, func, **kwargs):
                         if self.frozen:
                             raise ValueError("Cannot apply to a frozen treeclass.")
-                        return _at_reduce_apply(self, func, arg, **kwargs)
+                        return _at_reduce(self, func, arg, **kwargs)
+
+                return getterSetterIndexer()
+
+            @__getitem__.register(str)
+            @__getitem__.register(tuple)
+            def _(inner_self, *args):
+                """Non-boolean indexing"""
+
+                flatten_args = jtu.tree_leaves(args)
+
+                class getterSetterIndexer(treeIndexerMethods):
+                    def get(getter_setter_self, **kwargs):
+                        return _at_get(self, *flatten_args, **kwargs)
+
+                    def set(getter_setter_self, set_value, **kwargs):
+                        if self.frozen:
+                            raise ValueError("Cannot set to a frozen treeclass.")
+                        return _at_set(self, set_value, *flatten_args, **kwargs)
+
+                    def apply(getter_setter_self, func, **kwargs):
+                        if self.frozen:
+                            raise ValueError("Cannot apply to a frozen treeclass.")
+                        return _at_apply(self, func, *flatten_args, **kwargs)
+
+                    def reduce(getter_setter_self, func, **kwargs):
+                        if self.frozen:
+                            raise ValueError("Cannot apply to a frozen treeclass.")
+                        return _at_reduce(self, func, *flatten_args, **kwargs)
 
                 return getterSetterIndexer()
 
@@ -260,4 +356,3 @@ class treeIndexer:
     def __getitem__(self, *args):
         """alias for .at[].get()"""
         return self.at.__getitem__(*args).get()
-        # trunk-ignore(flake8/E501)

--- a/pytreeclass/src/tree_op_base.py
+++ b/pytreeclass/src/tree_op_base.py
@@ -93,22 +93,21 @@ def _append_math_op_aux(func):
 
             def recurse(tree, where, **kwargs):
                 for i, fld in enumerate(tree.__dataclass_fields__.values()):
+                    
                     cur_node = tree.__dict__[fld.name]
                     if not ptu.is_excluded(fld, tree) and ptu.is_treeclass(cur_node):
-                        if fld.name in where:
-                            # whole branch is true
+                        if fld.name ==  where:                            
                             tree.__dict__[fld.name] = jtu.tree_map(set_true, cur_node)
                         else:
                             recurse(cur_node, where, **kwargs)
                     else:
                         tree.__dict__[fld.name] = (
                             set_true(cur_node)
-                            if (fld.name in where)
+                            if (fld.name == where)
                             else set_false(cur_node)
                         )
-
                 return tree
-
+                
             return recurse(tree_copy, where, **kwargs)
 
         @inner_wrapper.register(type)

--- a/pytreeclass/src/tree_op_base.py
+++ b/pytreeclass/src/tree_op_base.py
@@ -4,7 +4,7 @@ import functools
 import operator as op
 
 import jax.numpy as jnp
-from jax.tree_util import tree_map, tree_reduce
+import jax.tree_util as jtu
 
 
 def _append_math_op(func):
@@ -14,38 +14,20 @@ def _append_math_op(func):
     def call(self, rhs=None):
 
         if rhs is None:  # unary operation
-            return tree_map(lambda x: func(x), self)
+            return jtu.tree_map(lambda x: func(x), self)
 
         elif isinstance(rhs, (int, float, complex, bool)):  # binary operation
-            return tree_map(lambda x: func(x, rhs), self) if rhs is not None else self
+            return (
+                jtu.tree_map(lambda x: func(x, rhs), self) if rhs is not None else self
+            )
 
         elif isinstance(rhs, type(self)):  # class instance
-            return tree_map(lambda x, y: func(x, y) if y is not None else x, self, rhs)
+            return jtu.tree_map(
+                lambda x, y: func(x, y) if y is not None else x, self, rhs
+            )
 
         else:
             raise NotImplementedError(f"Found type(rhs) = {type(rhs)}")
-
-    return call
-
-
-def _append_numpy_op(func):
-    """array operations"""
-
-    @functools.wraps(func)
-    def call(self, *args, **kwargs):
-        return tree_map(lambda node: func(node, *args, **kwargs), self)
-
-    return call
-
-
-def _append_reduced_numpy_op(func, reduce_op, init_val):
-    """reduced array operations"""
-
-    @functools.wraps(func)
-    def call(self, *args, **kwargs):
-        return tree_reduce(
-            lambda acc, cur: reduce_op(acc, func(cur, *args, **kwargs)), self, init_val
-        )
 
     return call
 
@@ -79,49 +61,8 @@ class treeOpBase:
     __truediv__ = _append_math_op(op.truediv)
     __xor__ = _append_math_op(op.xor)
 
-    imag = property(_append_numpy_op(jnp.imag))
-    real = property(_append_numpy_op(jnp.real))
-    conj = property(_append_numpy_op(jnp.conj))
-
-    abs = _append_numpy_op(jnp.abs)
-    amax = _append_numpy_op(jnp.amax)
-    amin = _append_numpy_op(jnp.amin)
-    arccos = _append_numpy_op(jnp.arccos)
-    arcsin = _append_numpy_op(jnp.arcsin)
-    sum = _append_numpy_op(jnp.sum)
-    prod = _append_numpy_op(jnp.prod)
-    mean = _append_numpy_op(jnp.mean)
-
-    reduce_abs = _append_reduced_numpy_op(jnp.abs, op.add, 0)
-    reduce_amax = _append_reduced_numpy_op(jnp.amax, op.add, 0)
-    reduce_amin = _append_reduced_numpy_op(jnp.amin, op.add, 0)
-    reduce_arccos = _append_reduced_numpy_op(jnp.arccos, op.add, 0)
-    reduce_arcsin = _append_reduced_numpy_op(jnp.arcsin, op.add, 0)
-    reduce_sum = _append_reduced_numpy_op(jnp.sum, op.add, 0)
-    reduce_prod = _append_reduced_numpy_op(jnp.prod, op.mul, 1)
-    reduce_mean = _append_reduced_numpy_op(jnp.mean, op.add, 0)
-
     def __or__(self, rhs):
         def node_or(x, y):
             return x if isinstance(x, jnp.ndarray) else (x or y)
 
-        return tree_map(node_or, self, rhs, is_leaf=lambda x: x is None)
-
-    def register_op(self, func, *, name, reduce_op=None, init_val=None):
-        """register a math operation"""
-
-        def element_call(*args, **kwargs):
-            return tree_map(lambda node: func(node, *args, **kwargs), self)
-
-        setattr(self, name, element_call)
-
-        if (reduce_op is not None) and (init_val is not None):
-
-            def reduced_call(*args, **kwargs):
-                return tree_reduce(
-                    lambda acc, cur: reduce_op(acc, func(cur, *args, **kwargs)),
-                    self,
-                    init_val,
-                )
-
-            setattr(self, f"reduce_{name}", reduced_call)
+        return jtu.tree_map(node_or, self, rhs, is_leaf=lambda x: x is None)

--- a/pytreeclass/src/tree_util.py
+++ b/pytreeclass/src/tree_util.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+import dataclasses
 import sys
 from dataclasses import field
+from typing import Any
 
 import jax
 import jax.numpy as jnp
+import jax.tree_util as jtu
 import numpy as np
-from jax.tree_util import tree_all, tree_leaves, tree_reduce
 
 
 def static_field(**kwargs):
@@ -46,12 +48,12 @@ def is_treeclass_equal(lhs, rhs):
         if isinstance(lhs_node, jnp.ndarray):
             return jnp.all(lhs_node == rhs_node)
         elif is_treeclass(lhs_node):
-            return tree_all(lhs_node, rhs_node)
+            return jtu.tree_all(lhs_node, rhs_node)
         else:
             return lhs_node == rhs_node
 
-    lhs_leaves = tree_leaves(lhs)
-    rhs_leaves = tree_leaves(rhs)
+    lhs_leaves = jtu.tree_leaves(lhs)
+    rhs_leaves = jtu.tree_leaves(rhs)
 
     for lhs_node, rhs_node in zip(lhs_leaves, rhs_leaves):
         if not assert_node(lhs_node, rhs_node):
@@ -59,9 +61,22 @@ def is_treeclass_equal(lhs, rhs):
     return True
 
 
+def is_excluded(fld: dataclasses.field, instance: Any) -> bool:
+    """Check if a field is excluded
+
+    Returns:
+        bool: boolean if the field should be excluded or not.
+    """
+    val = instance.__dict__[fld.name]
+    excluded_types = (str,)  # automatically excluded str from jax computations
+    excluded_by_type = isinstance(val, excluded_types)
+    excluded_by_meta = ("static" in fld.metadata) and fld.metadata["static"] is True  # fmt: skip
+    return excluded_by_type or excluded_by_meta
+
+
 def sequential_model_shape_eval(model, array):
     """Evaluate shape propagation of assumed sequential modules"""
-    leaves = tree_leaves(model, is_treeclass_leaf)
+    leaves = jtu.tree_leaves(model, is_treeclass_leaf)
     shape = [jax.eval_shape(lambda x: x, array)]
     for leave in leaves:
         shape += [jax.eval_shape(leave, shape[-1])]
@@ -108,7 +123,7 @@ def _reduce_count_and_size(leaf):
         rhs_count, rhs_size = _node_count_and_size(node)
         return (lhs_count + rhs_count, lhs_size + rhs_size)
 
-    return tree_reduce(reduce_func, leaf, (complex(0, 0), complex(0, 0)))
+    return jtu.tree_reduce(reduce_func, leaf, (complex(0, 0), complex(0, 0)))
 
 
 def _freeze_nodes(model):

--- a/pytreeclass/src/tree_util.py
+++ b/pytreeclass/src/tree_util.py
@@ -42,23 +42,19 @@ def is_treeclass_leaf(model):
 
 
 def is_treeclass_equal(lhs, rhs):
-    """assert all leaves are same . use jnp.all on jnp.arrays"""
+    """Assert if two treeclasses are equal"""
+    lhs_leaves, lhs_treedef = jtu.tree_flatten(lhs)
+    rhs_leaves, rhs_treedef = jtu.tree_flatten(rhs)
 
-    def assert_node(lhs_node, rhs_node):
-        if isinstance(lhs_node, jnp.ndarray):
-            return jnp.all(lhs_node == rhs_node)
-        elif is_treeclass(lhs_node):
-            return jtu.tree_all(lhs_node, rhs_node)
+    def is_node_equal(lhs_node, rhs_node):
+        if isinstance(lhs_node, jnp.ndarray) and isinstance(rhs_node, jnp.ndarray):
+            return jnp.array_equal(lhs_node, rhs_node)
         else:
             return lhs_node == rhs_node
 
-    lhs_leaves = jtu.tree_leaves(lhs)
-    rhs_leaves = jtu.tree_leaves(rhs)
-
-    for lhs_node, rhs_node in zip(lhs_leaves, rhs_leaves):
-        if not assert_node(lhs_node, rhs_node):
-            return False
-    return True
+    return (lhs_treedef == rhs_treedef) and all(
+        [is_node_equal(lhs_leaves[i], rhs_leaves[i]) for i in range(len(lhs_leaves))]
+    )
 
 
 def is_excluded(fld: dataclasses.field, instance: Any) -> bool:

--- a/pytreeclass/src/tree_viz.py
+++ b/pytreeclass/src/tree_viz.py
@@ -659,7 +659,9 @@ def tree_str(model, width: int = 40) -> str:
                         fmt += ")" + ("," if i < (cur_children_count - 1) else "")
 
                     else:
-                        cur_node_fmt = ("\n" + "\t" * (depth + 1)).join(
+                        multiline =  "\n" in f"{cur_node!s}" 
+                        cur_node_fmt =("\n" + "\t" * (depth + 1)) if multiline else ""
+                        cur_node_fmt += ("\n" + "\t" * (depth + 1)).join(
                             f"{cur_node!s}".split("\n")
                         )
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -20,23 +20,23 @@ class Linear:
         return x @ self.weight + self.bias
 
 
-def test_op():
-    @pytc.treeclass(op=False)
-    class StackedLinear:
-        def __init__(self, key, in_dim, out_dim, hidden_dim):
-            keys = jax.random.split(key, 3)
+# def test_op():
+#     @pytc.treeclass(op=False)
+#     class StackedLinear:
+#         def __init__(self, key, in_dim, out_dim, hidden_dim):
+#             keys = jax.random.split(key, 3)
 
-            # Declaring l1,l2,l3 as dataclass_fields is optional
-            # as l1,l2,l3 are Linear class that is wrapped with @pytc.treeclass
-            self.l1 = Linear(key=keys[0], in_dim=in_dim, out_dim=hidden_dim)
-            self.l2 = Linear(key=keys[1], in_dim=hidden_dim, out_dim=hidden_dim)
-            self.l3 = Linear(key=keys[2], in_dim=hidden_dim, out_dim=out_dim)
+#             # Declaring l1,l2,l3 as dataclass_fields is optional
+#             # as l1,l2,l3 are Linear class that is wrapped with @pytc.treeclass
+#             self.l1 = Linear(key=keys[0], in_dim=in_dim, out_dim=hidden_dim)
+#             self.l2 = Linear(key=keys[1], in_dim=hidden_dim, out_dim=hidden_dim)
+#             self.l3 = Linear(key=keys[2], in_dim=hidden_dim, out_dim=out_dim)
 
-    with pytest.raises(TypeError):
-        model = StackedLinear(
-            key=jax.random.PRNGKey(0), in_dim=2, out_dim=2, hidden_dim=2
-        )
-        model + model
+#     with pytest.raises(TypeError):
+#         model = StackedLinear(
+#             key=jax.random.PRNGKey(0), in_dim=2, out_dim=2, hidden_dim=2
+#         )
+#         model + model
 
 
 def test_field_only():

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -49,7 +49,7 @@ def test_getter_by_pytree():
 
     assert is_treeclass_equal(B, C)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         B = A.at[A].get()
 
     with pytest.raises(NotImplementedError):
@@ -59,19 +59,21 @@ def test_getter_by_pytree():
 def test_getter_by_param():
     A = Test(10, 20, 30, jnp.array([1, 2, 3, 4, 5]), "A")
 
-    B = A.at["a"].get()
+    B = A.at[A == "a"].get(array_as_leaves=False)
     assert is_treeclass_equal(B, Test(10, None, None, None, "A"))
 
-    B = A.at["a", "b"].get()
+    B = A.at[(A == "a") | (A == "b")].get(array_as_leaves=False)
     assert is_treeclass_equal(B, Test(10, 20, None, None, "A"))
 
-    B = A.at[""].get()
+    B = A.at[A == ""].get(array_as_leaves=False)
     assert is_treeclass_equal(B, Test(None, None, None, None, "A"))
 
-    B = A.at["a", "b", "c"].get()
+    B = A.at[(A == "a") | (A == "b") | (A == "c")].get(array_as_leaves=False)
     assert is_treeclass_equal(B, Test(10, 20, 30, None, "A"))
 
-    B = A.at["a", "b", "c", "d"].get()
+    B = A.at[(A == "a") | (A == "b") | (A == "c") | (A == "d")].get(
+        array_as_leaves=False
+    )
     assert is_treeclass_equal(B, Test(10, 20, 30, jnp.array([1, 2, 3, 4, 5]), "A"))
 
     @treeclass
@@ -95,7 +97,7 @@ def test_getter_by_param():
         d: L1 = L1()
 
     t = L2()
-    lhs = t.at["a"].get()
+    lhs = t.at[t == "a"].get()
     rhs = L2(10, None, None, L1(1, None, None, L0(1, None, None)))
     assert is_treeclass_equal(lhs, rhs)
 
@@ -127,7 +129,7 @@ def test_setter_by_pytree():
 
     A = Test(10, 20, 30, jnp.array([1, 2, 3, 4, 5]), "A")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         B = A.at[A].set(0)
 
     with pytest.raises(NotImplementedError):
@@ -154,7 +156,7 @@ def test_setter_by_pytree():
         d: L1 = L1()
 
     t = L2()
-    lhs = t.at["a"].set(100)
+    lhs = t.at[t == "a"].set(100)
     rhs = L2(100, 20, 30, L1(100, 2, 3, L0(100, 2, 3)))
     assert is_treeclass_equal(lhs, rhs)
 
@@ -162,13 +164,13 @@ def test_setter_by_pytree():
 def test_setter_by_param():
     A = Test(10, 20, 30, jnp.array([1, 2, 3, 4, 5]), "A")
 
-    B = A.at["a"].set(0)
+    B = A.at[A == "a"].set(0)
     assert is_treeclass_equal(B, Test(0, 20, 30, jnp.array([1, 2, 3, 4, 5]), "A"))
 
-    B = A.at["a", "b"].set(0)
+    B = A.at[(A == "a") | (A == "b")].set(0)
     assert is_treeclass_equal(B, Test(0, 0, 30, jnp.array([1, 2, 3, 4, 5]), "A"))
 
-    B = A.at["a", "b", "c"].set(0)
+    B = A.at[(A == "a") | (A == "b") | (A == "c")].set(0)
     assert is_treeclass_equal(B, Test(0, 0, 0, jnp.array([1, 2, 3, 4, 5]), "A"))
 
 
@@ -215,7 +217,7 @@ def test_apply_and_its_derivatives():
         d: L1 = L1()
 
     t = L2()
-    lhs = t.at["a"].apply(lambda _: 100)
+    lhs = t.at[t == "a"].apply(lambda _: 100)
     rhs = L2(100, 20, 30, L1(100, 2, 3, L0(100, 2, 3)))
     assert is_treeclass_equal(lhs, rhs)
 
@@ -261,50 +263,50 @@ def test_apply_and_its_derivatives():
     # by param
 
     lhs = A(1, 2, jnp.array([1, 2, 3, 4, 5]))
-    rhs = init.at["a"].apply(lambda x: x**2)
+    rhs = init.at[init == "a"].apply(lambda x: x**2)
     assert is_treeclass_equal(lhs, rhs)
 
     lhs = A(2, 2, jnp.array([1, 2, 3, 4, 5]))
-    rhs = init.at["a"].apply(lambda x: x + 1)
+    rhs = init.at[init == "a"].apply(lambda x: x + 1)
     assert is_treeclass_equal(lhs, rhs)
 
     lhs = A(20, 2, jnp.array([1, 2, 3, 4, 5]))
-    rhs = init.at["a"].apply(lambda x: (x + 1) * 10)
+    rhs = init.at[init == "a"].apply(lambda x: (x + 1) * 10)
     assert is_treeclass_equal(lhs, rhs)
 
     lhs = A(2, 2, jnp.array([1, 2, 3, 4, 5]))
-    rhs = init.at["a"].add(1)
+    rhs = init.at[init == "a"].add(1)
     assert is_treeclass_equal(lhs, rhs)
 
     lhs = A(0.5, 2, jnp.array([1, 2, 3, 4, 5]))
-    rhs = init.at["a"].divide(2.0)
+    rhs = init.at[init == "a"].divide(2.0)
     assert is_treeclass_equal(lhs, rhs)
 
     lhs = A(1, 2, jnp.array([1, 2, 3, 4, 5]))
-    rhs = init.at["a"].min(1)
+    rhs = init.at[init == "a"].min(1)
     assert is_treeclass_equal(lhs, rhs)
 
     lhs = A(4, 2, jnp.array([1, 2, 3, 4, 5]))
-    rhs = init.at["a"].max(4)
+    rhs = init.at[init == "a"].max(4)
     assert is_treeclass_equal(lhs, rhs)
 
     lhs = A(1, 2, jnp.array([1, 2, 3, 4, 5]))
-    rhs = init.at["a"].power(2)
+    rhs = init.at[init == "a"].power(2)
     assert is_treeclass_equal(lhs, rhs)
 
     lhs = A(2, 2, jnp.array([1, 2, 3, 4, 5]))
-    rhs = init.at["a"].multiply(2)
+    rhs = init.at[init == "a"].multiply(2)
     assert is_treeclass_equal(lhs, rhs)
 
     # by param
     with pytest.raises(ValueError):
-        init.freeze().at["a"].apply(lambda x: x**2)
+        init.freeze().at[init == "a"].apply(lambda x: x**2)
 
     with pytest.raises(ValueError):
-        init.freeze().at["a", "b"].apply(lambda x: x**2)
+        init.freeze().at[(init == "a") | (A == "b")].apply(lambda x: x**2)
 
     with pytest.raises(ValueError):
-        init.freeze().at["a", "b"].set(0)
+        init.freeze().at[(init == "a") | (A == "b")].set(0)
 
 
 def test_reduce():

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -16,59 +16,6 @@ class Test:
     name: str
 
 
-def test_getter_by_param():
-    A = Test(10, 20, 30, jnp.array([1, 2, 3, 4, 5]), "A")
-
-    B = A.at["a"].get()
-    assert is_treeclass_equal(B, Test(10, None, None, None, "A"))
-
-    B = A.at["a", "b"].get()
-    assert is_treeclass_equal(B, Test(10, 20, None, None, "A"))
-
-    B = A.at[""].get()
-    assert is_treeclass_equal(B, Test(None, None, None, None, "A"))
-
-    B = A.at["a", "b", "c"].get()
-    assert is_treeclass_equal(B, Test(10, 20, 30, None, "A"))
-
-    B = A.at["a", "b", "c", "d"].get()
-    assert is_treeclass_equal(B, Test(10, 20, 30, jnp.array([1, 2, 3, 4, 5]), "A"))
-
-
-def test_getter_by_slice():
-    A = Test(10, 20, 30, jnp.array([1, 2, 3, 4, 5]), "A")
-
-    B = A.at[0:1].get()
-    assert is_treeclass_equal(B, Test(10, None, None, jnp.array([]), "A"))
-
-    B = A.at[0:2].get()
-    assert is_treeclass_equal(B, Test(10, 20, None, jnp.array([]), "A"))
-
-    B = A.at[:-1].get()
-    assert is_treeclass_equal(B, Test(10, 20, 30, jnp.array([1, 2, 3, 4, 5]), "A"))
-
-    B = A.at[:].get()
-    assert is_treeclass_equal(B, Test(10, 20, 30, jnp.array([1, 2, 3, 4, 5]), "A"))
-
-
-def test_getter_by_int():
-    A = Test(10, 20, 30, jnp.array([1, 2, 3, 4, 5]), "A")
-
-    B = A.at[0].get()
-    assert is_treeclass_equal(B, Test(10, None, None, None, "A"))
-
-    B = A.at[1].get()
-    assert is_treeclass_equal(B, Test(None, 20, None, None, "A"))
-
-    B = A.at[2].get()
-    assert is_treeclass_equal(B, Test(None, None, 30, None, "A"))
-
-    B = A.at[3].get()
-    assert is_treeclass_equal(
-        B, Test(None, None, None, jnp.array([1, 2, 3, 4, 5]), "A")
-    )
-
-
 def test_getter_by_pytree():
     @treeclass
     class level1:
@@ -106,46 +53,7 @@ def test_getter_by_pytree():
         B = A.at[A].get()
 
     # with pytest.raises(NotImplementedError):
-    B = A.at[0].get()
-
-
-def test_setter_by_param():
-    A = Test(10, 20, 30, jnp.array([1, 2, 3, 4, 5]), "A")
-
-    B = A.at["a"].set(0)
-    assert is_treeclass_equal(B, Test(0, 20, 30, jnp.array([1, 2, 3, 4, 5]), "A"))
-
-    B = A.at["a", "b"].set(0)
-    assert is_treeclass_equal(B, Test(0, 0, 30, jnp.array([1, 2, 3, 4, 5]), "A"))
-
-    B = A.at["a", "b", "c"].set(0)
-    assert is_treeclass_equal(B, Test(0, 0, 0, jnp.array([1, 2, 3, 4, 5]), "A"))
-
-
-def test_setter_by_slice():
-    A = Test(10, 20, 30, jnp.array([1, 2, 3, 4, 5]), "A")
-
-    B = A.at[0:1].set(0)
-    assert is_treeclass_equal(B, Test(0, 20, 30, jnp.array([1, 2, 3, 4, 5]), "A"))
-
-    B = A.at[0:2].set(0)
-    assert is_treeclass_equal(B, Test(0, 0, 30, jnp.array([1, 2, 3, 4, 5]), "A"))
-
-    B = A.at[0:3].set(0)
-    assert is_treeclass_equal(B, Test(0, 0, 0, jnp.array([1, 2, 3, 4, 5]), "A"))
-
-
-def test_setter_by_int():
-    A = Test(10, 20, 30, jnp.array([1, 2, 3, 4, 5]), "A")
-
-    B = A.at[0].set(0)
-    assert is_treeclass_equal(B, Test(0, 20, 30, jnp.array([1, 2, 3, 4, 5]), "A"))
-
-    B = A.at[1].set(0)
-    assert is_treeclass_equal(B, Test(10, 0, 30, jnp.array([1, 2, 3, 4, 5]), "A"))
-
-    B = A.at[2].set(0)
-    assert is_treeclass_equal(B, Test(10, 20, 0, jnp.array([1, 2, 3, 4, 5]), "A"))
+    # B = A.at[0].get()
 
 
 def test_setter_by_pytree():
@@ -179,7 +87,7 @@ def test_setter_by_pytree():
         B = A.at[A].set(0)
 
     # with pytest.raises(NotImplementedError):
-    B = A.at[0].set(0)
+    # B = A.at[0].set(0)
 
 
 def test_apply_and_its_derivatives():
@@ -240,76 +148,5 @@ def test_apply_and_its_derivatives():
     assert is_treeclass_equal(lhs, rhs)
 
     lhs = A(1, 4, jnp.array([1, 4, 3, 4, 5]))
-    rhs = init.at[init==2].multiply(2)
+    rhs = init.at[init == 2].multiply(2)
     assert is_treeclass_equal(lhs, rhs)
-
-    # by param
-
-    lhs = A(1, 2, jnp.array([1, 2, 3, 4, 5]))
-    rhs = init.at["a"].apply(lambda x: x**2)
-    assert is_treeclass_equal(lhs, rhs)
-
-    lhs = A(2, 2, jnp.array([1, 2, 3, 4, 5]))
-    rhs = init.at["a"].apply(lambda x: x + 1)
-    assert is_treeclass_equal(lhs, rhs)
-
-    lhs = A(20, 2, jnp.array([1, 2, 3, 4, 5]))
-    rhs = init.at["a"].apply(lambda x: (x + 1) * 10)
-    assert is_treeclass_equal(lhs, rhs)
-
-    lhs = A(2, 2, jnp.array([1, 2, 3, 4, 5]))
-    rhs = init.at["a"].add(1)
-    assert is_treeclass_equal(lhs, rhs)
-
-    lhs = A(0.5, 2, jnp.array([1, 2, 3, 4, 5]))
-    rhs = init.at["a"].divide(2.0)
-    assert is_treeclass_equal(lhs, rhs)
-
-    lhs = A(1, 2, jnp.array([1, 2, 3, 4, 5]))
-    rhs = init.at["a"].min(1)
-    assert is_treeclass_equal(lhs, rhs)
-
-    lhs = A(4, 2, jnp.array([1, 2, 3, 4, 5]))
-    rhs = init.at["a"].max(4)
-    assert is_treeclass_equal(lhs, rhs)
-
-    lhs = A(1, 2, jnp.array([1, 2, 3, 4, 5]))
-    rhs = init.at["a"].power(2)
-    assert is_treeclass_equal(lhs, rhs)
-
-    lhs = A(2, 2, jnp.array([1, 2, 3, 4, 5]))
-    rhs = init.at["a"].multiply(2)
-    assert is_treeclass_equal(lhs, rhs)
-
-    # by param
-    with pytest.raises(ValueError):
-        init.freeze().at["a"].apply(lambda x: x**2)
-
-    with pytest.raises(ValueError):
-        init.freeze().at["a", "b"].apply(lambda x: x**2)
-
-    with pytest.raises(ValueError):
-        init.freeze().at["a", "b"].set(0)
-
-    # by slice
-    with pytest.raises(ValueError):
-        init.freeze().at[:].apply(lambda x: x**2)
-
-    with pytest.raises(ValueError):
-        init.freeze().at[0].apply(lambda x: x**2)
-
-    # by pytree
-    with pytest.raises(ValueError):
-        init.freeze().at[init > 1].apply(lambda x: x**2)
-
-    with pytest.raises(ValueError):
-        init.freeze().at[init == 1].apply(lambda x: x**2)
-    
-    with pytest.raises(NotImplementedError):
-        init.at[1.0].get()
-
-    with pytest.raises(NotImplementedError):
-        init.at[1.0].set(0)
-
-    with pytest.raises(NotImplementedError):
-        init.at[1.0].apply(lambda x:x)

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -74,6 +74,31 @@ def test_getter_by_param():
     B = A.at["a", "b", "c", "d"].get()
     assert is_treeclass_equal(B, Test(10, 20, 30, jnp.array([1, 2, 3, 4, 5]), "A"))
 
+    @treeclass
+    class L0:
+        a: int = 1
+        b: int = 2
+        c: int = 3
+
+    @treeclass
+    class L1:
+        a: int = 1
+        b: int = 2
+        c: int = 3
+        d: L0 = L0()
+
+    @treeclass
+    class L2:
+        a: int = 10
+        b: int = 20
+        c: int = 30
+        d: L1 = L1()
+
+    t = L2()
+    lhs = t.at["a"].get()
+    rhs = L2(10, None, None, L1(1, None, None, L0(1, None, None)))
+    assert is_treeclass_equal(lhs, rhs)
+
 
 def test_setter_by_pytree():
     @treeclass
@@ -107,6 +132,31 @@ def test_setter_by_pytree():
 
     with pytest.raises(NotImplementedError):
         B = A.at[0].set(0)
+
+    @treeclass
+    class L0:
+        a: int = 1
+        b: int = 2
+        c: int = 3
+
+    @treeclass
+    class L1:
+        a: int = 1
+        b: int = 2
+        c: int = 3
+        d: L0 = L0()
+
+    @treeclass
+    class L2:
+        a: int = 10
+        b: int = 20
+        c: int = 30
+        d: L1 = L1()
+
+    t = L2()
+    lhs = t.at["a"].set(100)
+    rhs = L2(100, 20, 30, L1(100, 2, 3, L0(100, 2, 3)))
+    assert is_treeclass_equal(lhs, rhs)
 
 
 def test_setter_by_param():
@@ -142,6 +192,31 @@ def test_apply_and_its_derivatives():
 
     lhs = A(20, 30, jnp.array([20, 30, 40, 50, 60]))
     rhs = init.at[init == init].apply(lambda x: (x + 1) * 10)
+    assert is_treeclass_equal(lhs, rhs)
+
+    @treeclass
+    class L0:
+        a: int = 1
+        b: int = 2
+        c: int = 3
+
+    @treeclass
+    class L1:
+        a: int = 1
+        b: int = 2
+        c: int = 3
+        d: L0 = L0()
+
+    @treeclass
+    class L2:
+        a: int = 10
+        b: int = 20
+        c: int = 30
+        d: L1 = L1()
+
+    t = L2()
+    lhs = t.at["a"].apply(lambda _: 100)
+    rhs = L2(100, 20, 30, L1(100, 2, 3, L0(100, 2, 3)))
     assert is_treeclass_equal(lhs, rhs)
 
     lhs = A(2, 3, jnp.array([2, 3, 4, 5, 6]))

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -1,5 +1,4 @@
 import jax.numpy as jnp
-import pytest
 
 from pytreeclass import static_field, treeclass
 
@@ -81,10 +80,10 @@ def test_asdict():
 #     assert (A["a"] + 10 | A) == Test(20, 20, 30, "A")
 
 
-def test_op_false():
-    @treeclass(op=False)
-    class Test:
-        a: int
+# def test_op_false():
+#     @treeclass(op=False)
+#     class Test:
+#         a: int
 
-    with pytest.raises(TypeError):
-        Test(1) + Test(2)
+#     with pytest.raises(TypeError):
+#         Test(1) + Test(2)

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -26,7 +26,7 @@ def test_ops():
     assert (A + A) == Test(20, 40, 60, "A")
     assert (A - A) == Test(0, 0, 0, "A")
     # assert ((A["a"] + A) | A) == Test(20, 20, 30, "A")
-    assert A.reduce_mean() == jnp.array(60)
+    # assert A.reduce_mean() == jnp.array(60)
     assert abs(A) == A
 
     @treeclass
@@ -54,11 +54,11 @@ def test_ops():
     # numpy ops
     A = Test(a=jnp.array([-10, -10]), b=1, name="A")
 
-    assert A.reduce_amax() == jnp.array(-9)
-    assert A.reduce_amin() == jnp.array(-9)
-    assert A.reduce_sum() == jnp.array(-19)
-    assert A.reduce_prod() == jnp.array(100)
-    assert A.reduce_mean() == jnp.array(-9)
+    # assert A.reduce_amax() == jnp.array(-9)
+    # assert A.reduce_amin() == jnp.array(-9)
+    # assert A.reduce_sum() == jnp.array(-19)
+    # assert A.reduce_prod() == jnp.array(100)
+    # assert A.reduce_mean() == jnp.array(-9)
 
 
 def test_asdict():
@@ -66,19 +66,19 @@ def test_asdict():
     assert A.asdict() == {"a": 10, "b": 20, "c": 30, "name": "A"}
 
 
-def test_register_op():
-    A = Test(10, 20, 30, "A")
-    A.register_op(
-        func=jnp.prod, name="product", reduce_op=lambda x, y: x * y, init_val=1
-    )
+# def test_register_op():
+#     A = Test(10, 20, 30, "A")
+#     A.register_op(
+#         func=jnp.prod, name="product", reduce_op=lambda x, y: x * y, init_val=1
+#     )
 
-    assert A.reduce_product() == 6000
-    assert (A * A).reduce_mean() == 1400
+#     assert A.reduce_product() == 6000
+#     assert (A * A).reduce_mean() == 1400
 
-    with pytest.raises(NotImplementedError):
-        A + "s"
+#     with pytest.raises(NotImplementedError):
+#         A + "s"
 
-    assert (A["a"] + 10 | A) == Test(20, 20, 30, "A")
+#     assert (A["a"] + 10 | A) == Test(20, 20, 30, "A")
 
 
 def test_op_false():


### PR DESCRIPTION
- Deprecation
1 - `op` keyword in `treeclass`
2- `numpy` operations , `reduce_` , `register_op`
3- integer indexing

- Additions and changes
1- Filtering through `.at` for field name,field type and field metadata
2- Improved `__repr__` / `__str__`
3- Moves `numpy`, `reduce` as part of `.at[]` filtering


