### PR TITLE
support for tree nondiff filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ StackedLinear(
 )
 ```
 
-# 📜 Stateful computations<a id="StatefulComputation"></a>
+## 📜 Stateful computations<a id="StatefulComputation"></a>
 
 First, [Under jax.jit jax requires states to be explicit](https://jax.readthedocs.io/en/latest/jax-101/07-state.html?highlight=state), this means that for any class instance; variables needs to be separated from the class and be passed explictly. However when using @pytc.treeclass no need to separate the instance variables ; instead the whole instance is passed as a state.
 
@@ -553,10 +553,8 @@ Physics-based Neural network library
 
 ## ⌛ Benchmarking<a id="Benchmarking"></a><a href="https://colab.research.google.com/github/ASEM000/PyTreeClass/blob/main/PyTreeClass_benchmarks.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
 
-
 `tree_flatten`/ `tree_unflatten` are integral steps in any training / or `jax` operation.
 The following is a comparison of `PyTreeClass`, `Treex`, and `Equinox` for an identical model with 9 `Linear` layers for the `tree_flatten`/ `tree_unflatten` process.
-
 
 <table>
 <tr>

--- a/pytreeclass/_src/misc.py
+++ b/pytreeclass/_src/misc.py
@@ -9,12 +9,15 @@ from typing import Any, Callable
 import jax.numpy as jnp
 import jax.tree_util as jtu
 
+from pytreeclass._src.dispatch import dispatch
 from pytreeclass._src.tree_util import (
     _pytree_map,
     _tree_immutate,
     _tree_mutate,
     is_treeclass,
 )
+
+PyTree = Any
 
 
 def static_field(**kwargs):
@@ -87,74 +90,191 @@ def _is_nondiff(item):
     return _is_nondiff_item(item)
 
 
-def filter_nondiff(tree):
-    """filter non-differentiable fields from a treeclass instance
-
-    Note:
-        Mark fields as non-differentiable with adding metadata `dict(static=True,nondiff=True)`
-        the way it is done is by adding a field `__undeclared_fields__` to the treeclass instance
-        that contains the non-differentiable fields.
-        This is done to avoid mutating the original treeclass class or copying .
-
-        during the `tree_flatten`, tree_fields are the combination of
-        {__dataclass_fields__, __undeclared_fields__} this means that a field defined
-        in `__undeclared_fields__` with the same name as in __dataclass_fields__
-        will override its properties, this is useful if you want to change the metadata
-        of a field but don't want to change the original field definition.
-
-    Example:
-        @pytc.treeclass
-        class Test:
-            a: int = 1.
-            b: int = 2
-            c: int = 3
-            act: Callable = jax.nn.tanh
-
-            def __call__(self,x):
-                return self.act(x + self.a)
-
-        @jax.value_and_grad
-        def loss_func(model):
-            return jnp.mean((model(1.)-0.5)**2)
-
-        @jax.jit
-        def update(model):
-            value,grad = loss_func(model)
-            return value,model-1e-3*grad
-
-        model = Test()
-        print(model)
-        # Test(a=1.0,b=2,c=3,act=tanh(x))
-
-        model = filter_nondiff(model)
-        print(f"{model!r}")
-        # Test(a=1.0,*b=2,*c=3,*act=tanh(x))
-
-        for _ in range(1,10001):
-            value,model = update(model)
-
-        print(model)
-        # Test(a=-0.36423424,*b=2,*c=3,*act=tanh(x))
-
-    """
+def filter_nondiff(tree, where: PyTree | None = None):
     # we use _pytree_map to add {nondiff:True} to a non-differentiable field metadata
     # this operation is done in-place and changes the tree structure
     # thus its not bundled with `.at[..]` as it will break composability
-    return _pytree_map(
-        tree,
-        cond=lambda _, __, node_item: _is_nondiff(node_item),
-        true_func=lambda tree, field_item, node_item: {
-            **tree.__undeclared_fields__,
-            **{
-                field_item.name: _copy_field(
-                    field_item, field_aux_metadata={"static": True, "nondiff": True}
-                )
+
+    @dispatch(argnum=1)
+    def _static(tree, where: PyTree | None):
+        raise TypeError(
+            f"where must be a PyTree of same structure. Found {type(where)}"
+        )
+
+    @_static.register(type(None))
+    def _(tree, where: None):
+        """filter non-differentiable fields from a treeclass instance
+
+        Note:
+            Mark fields as non-differentiable with adding metadata `dict(static=True,nondiff=True)`
+            the way it is done is by adding a field `__undeclared_fields__` to the treeclass instance
+            that contains the non-differentiable fields.
+            This is done to avoid mutating the original treeclass class or copying .
+
+            during the `tree_flatten`, tree_fields are the combination of
+            {__dataclass_fields__, __undeclared_fields__} this means that a field defined
+            in `__undeclared_fields__` with the same name as in __dataclass_fields__
+            will override its properties, this is useful if you want to change the metadata
+            of a field but don't want to change the original field definition.
+
+        Example:
+            @pytc.treeclass
+            class Linear:
+                weight: jnp.ndarray
+                bias: jnp.ndarray
+                other: jnp.ndarray = (1,2,3,4)
+                a: int = 1
+                b: float = 1.0
+                c: int = 1
+                d: float = 2.0
+                act : Callable = jax.nn.tanh
+
+                def __init__(self,in_dim,out_dim):
+                    self.weight = jnp.ones((in_dim,out_dim))
+                    self.bias =  jnp.ones((1,out_dim))
+
+                def __call__(self,x):
+                    return self.act(self.b+x)
+
+            @jax.value_and_grad
+            def loss_func(model):
+                return jnp.mean((model(1.)-0.5)**2)
+
+            @jax.jit
+            def update(model):
+                value,grad = loss_func(model)
+                return value,model-1e-3*grad
+
+            def train(model,epochs=10_000):
+                model = filter_nondiff(model)
+                for _ in range(epochs):
+                    value,model = update(model)
+                return model
+
+            >>> model = Linear(1,1)
+            >>> model = train(model)
+            >>> print(model)
+            # Linear(
+            #   weight=[[1.]],
+            #   bias=[[1.]],
+            #   *other=(1,2,3,4),
+            #   *a=1,
+            #   b=-0.36423424,
+            #   *c=1,
+            #   d=2.0,
+            #   *act=tanh(x)
+            # )
+        """
+        # this dispatch filter the non-differentiable fields from the tree based
+        # on the node value.
+        # in essence any field with non-differentiable value is filtered out.
+        return _pytree_map(
+            tree,
+            # condition is a lambda function that returns True if the field is non-differentiable
+            cond=lambda _, __, node_item: _is_nondiff(node_item),
+            # Extends the field metadata to add {nondiff:True}
+            true_func=lambda tree, field_item, node_item: {
+                **tree.__undeclared_fields__,
+                **{
+                    field_item.name: _copy_field(
+                        field_item, field_aux_metadata={"static": True, "nondiff": True}
+                    )
+                },
             },
-        },
-        false_func=lambda tree, field_item, node_item: tree.__undeclared_fields__,
-        attr_func=lambda _, __, ___: "__undeclared_fields__",
-        is_leaf=lambda _, field_item, __: field_item.metadata.get("static", False),
-    )
+            # keep the field as is
+            false_func=lambda tree, field_item, node_item: tree.__undeclared_fields__,
+            attr_func=lambda _, __, ___: "__undeclared_fields__",
+            # do not recurse if the field is `static`
+            is_leaf=lambda _, field_item, __: field_item.metadata.get("static", False),
+        )
+
+    @_static.register(type(tree))
+    def _(tree, where: PyTree):
+        """
+        this dispatch marks fields as non-differentiable by using `where` mask.
+
+        Example:
+            @pytc.treeclass
+            class L0:
+                a: int = 1
+                b: int = 2
+                c: int = 3
+
+            @pytc.treeclass
+            class L1:
+                a: int = 1
+                b: int = 2
+                c: int = 3
+                d: L0 = L0()
+
+            @pytc.treeclass
+            class L2:
+                a: int = 10
+                b: int = 20
+                c: int = 30
+                d: L1 = L1()
+
+            >>> t = L2()
+
+            >>> print(t.tree_diagram())
+            # L2
+            #     ├── a=10
+            #     ├── b=20
+            #     ├── c=30
+            #     └── d=L1
+            #         ├── a=1
+            #         ├── b=2
+            #         ├── c=3
+            #         └── d=L0
+            #             ├── a=1
+            #             ├── b=2
+            #             └── c=3
+
+            # Let's mark `a` and `b`  in `L0` as non-differentiable
+            # we can do this by using `where` mask
+
+            >>> t = t.at["d"].at["d"].set(filter_nondiff(t.d.d, where= L0(a=True,b=True, c=False)))
+
+            >>> print(t.tree_diagram())
+            # L2
+            #     ├── a=10
+            #     ├── b=20
+            #     ├── c=30
+            #     └── d=L1
+            #         ├── a=1
+            #         ├── b=2
+            #         ├── c=3
+            #         └── d=L0
+            #             ├*─ a=1
+            #             ├*─ b=2
+            #             └── c=3
+            # note `*` indicates that the field is non-differentiable
+        """
+        # this dispaatch sets field non-differentiable if the corresponding field in where is True
+        # in essence `where` is a mask of the same structure as the tree that indicates which fields
+        # to filter out from gradient computation.
+        return _pytree_map(
+            tree,
+            # condition is a PyTree of booleans that indicates which fields to filter out
+            cond=where,
+            # Extends the field metadata to add {nondiff:True}
+            true_func=lambda tree, field_item, node_item: {
+                **tree.__undeclared_fields__,
+                **{
+                    field_item.name: _copy_field(
+                        field_item, field_aux_metadata={"static": True, "nondiff": True}
+                    )
+                },
+            },
+            # keep the field as is
+            false_func=lambda tree, field_item, node_item: tree.__undeclared_fields__,
+            # the attribute to update is `__undeclared_fields__`
+            attr_func=lambda _, __, ___: "__undeclared_fields__",
+            # do not recurse if the field is `static`
+            is_leaf=lambda _, field_item, __: field_item.metadata.get("static", False),
+        )
+
+    return _static(tree, where)
 
 
 def unfilter_nondiff(tree):

--- a/pytreeclass/_src/tree_util.py
+++ b/pytreeclass/_src/tree_util.py
@@ -144,7 +144,12 @@ def _tree_hash(tree):
         else:
             return node
 
-    return hash(tuple(jtu.tree_map(_hash_node, jtu.tree_leaves(tree))))
+    return hash(
+        (
+            tuple(jtu.tree_map(_hash_node, jtu.tree_leaves(tree))),
+            jtu.tree_structure(tree),
+        )
+    )
 
 
 def tree_freeze(tree):

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -563,7 +563,7 @@ def test_apply_and_its_derivatives():
 
     t = L2()
     lhs = t.at[t != {"name": "a"}].apply(lambda _: 100)
-    rhs = L2(10, 100, 100, L1(1, 100, 100, L0(1, 100, 100)))
+    rhs = L2(10, 100, 100, L1(100, 100, 100, L0(100, 100, 100)))
 
     assert is_treeclass_equal(lhs, rhs)
 


### PR DESCRIPTION
this branch adds the functionality to make fields non-differentiable either by
- provide a boolean PyTree mask to manually choose which field to choose non-differentiable.
- providing no mask. Thus all non-differentiable values will be automatically detected
