### PR TITLE
Enable regex str comparison

### DIFF
--- a/pytreeclass/_src/tree_op.py
+++ b/pytreeclass/_src/tree_op.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import functools as ft
 import operator as op
+import re
 from dataclasses import Field
 from typing import Any, Callable, Generator
 
@@ -142,12 +143,25 @@ def _tree_hash(tree):
 
 
 def _eq(lhs, rhs):
-    # (x == int)  <-> isinstance(x,int)
-    return isinstance(lhs, rhs) if isinstance(rhs, type) else op.eq(lhs, rhs)
+    if isinstance(rhs, type):
+        # rhs is a type (tree == int ) will perform a instance check
+        return isinstance(lhs, rhs)
+    elif isinstance(rhs, str):
+        # rhs is a string for (tree == "a") will perform a field name check using regex
+        found = re.findall(rhs, lhs)
+        return len(found) > 0 and found[0] == lhs
+    return op.eq(lhs, rhs)
 
 
 def _ne(lhs, rhs):
-    return not isinstance(lhs, rhs) if isinstance(rhs, type) else op.ne(lhs, rhs)
+    if isinstance(rhs, type):
+        # rhs is a type (tree == int ) will perform a instance check
+        return not isinstance(lhs, rhs)
+    elif isinstance(rhs, str):
+        # rhs is a string for (tree == "a") will perform a field name check using regex
+        found = re.findall(rhs, lhs)
+        return len(found) == 0 or found[0] != lhs
+    return op.ne(lhs, rhs)
 
 
 class _treeOp:

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -5,7 +5,7 @@ import pytest
 from jax import numpy as jnp
 
 import pytreeclass as pytc
-from pytreeclass._src.tree_util import tree_copy
+from pytreeclass._src.tree_util import _mutable, tree_copy
 from pytreeclass.treeclass import ImmutableInstanceError
 
 
@@ -126,3 +126,19 @@ def test_delattr():
         class L1:
             def __delattr__(self, name):
                 pass
+
+    @pytc.treeclass
+    class L2:
+        a: int = 1
+
+        @_mutable
+        def delete(self, name):
+            del self.a
+
+    t = L2()
+    t.delete("a")
+
+
+def test_field():
+    with pytest.raises(ValueError):
+        pytc.field(nondiff=True, frozen=True)

--- a/tests/test_op.py
+++ b/tests/test_op.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import jax.numpy as jnp
 import pytest
 
@@ -83,3 +85,28 @@ def test_dispatched_tree_map():
             ...
 
         _dispatched_op_tree_map(lambda x, y: x, 1, A())
+
+
+def test_at_str_regex():
+    @pytc.treeclass
+    class Test:
+        a_conv: int = 0
+        b_conv: jnp.ndarray = jnp.array([1, 2, 3])
+        c: tuple[int, ...] = (1, 2, 3)
+
+    t = Test()
+
+    t = t == r".*conv"
+    assert pytc.is_treeclass_equal(
+        t, Test(True, jnp.array([True, True, True]), (False, False, False))
+    )
+
+    t = t != r".*conv"
+    assert pytc.is_treeclass_equal(
+        t, Test(False, jnp.array([False, False, False]), (True, True, True))
+    )
+
+    t = t == r"c"
+    assert pytc.is_treeclass_equal(
+        t, Test(False, jnp.array([False, False, False]), (True, True, True))
+    )


### PR DESCRIPTION
`tree == "string"` will perform regex-based search for filtering
example

```python
import pytreeclass as pytc 
import jax.numpy as jnp

@pytc.treeclass
class Test:
    a_conv: int = 0
    b_conv: jnp.ndarray = jnp.array([1, 2, 3])
    c: tuple[int, ...] = (1, 2, 3)

t = Test()
print(t == r".*conv")
#Test(
#  a_conv=True,
#  b_conv=[ True  True  True],
#  c=(False,False,False)
#)
```

Useful for filtering more than one layer by name. as shown in the example.
Previously `model == string` will match exactly the node name.