### PR TITLE
Advanced tree indexing

### DIFF
--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -442,6 +442,57 @@ def test_attribute_error():
         t.at["[b"].get()
 
 
+def test_indexget():
+    @pytc.treeclass
+    class l0:
+        a: int = 2
+
+    @pytc.treeclass
+    class Test:
+        a: int = 1
+        b: l0 = l0()
+
+    t = Test()
+    assert pytc.is_tree_equal(t.at[0].get(), Test(1, l0(None)))
+    assert pytc.is_tree_equal(t.at[1].at[0].get(), Test(None, l0(2)))
+
+
+def test_index_set():
+    @pytc.treeclass
+    class l0:
+        a: int = 2
+
+    @pytc.treeclass
+    class Test:
+        a: int = 1
+        b: l0 = l0()
+
+    t = Test()
+    t.at["a"].set(10)
+
+    assert pytc.is_tree_equal(t, Test())
+    assert pytc.is_tree_equal(t.at[0].set(10), Test(10, l0()))
+    assert pytc.is_tree_equal(t.at[1].at[0].set(100), Test(1, l0(100)))
+
+
+def test_index_apply():
+    @pytc.treeclass
+    class l0:
+        a: int = 2
+
+    @pytc.treeclass
+    class Test:
+        a: int = 1
+        b: l0 = l0()
+
+    t = Test()
+    t.at["a"].apply(lambda _: 10)
+
+    assert pytc.is_tree_equal(t, Test())
+    assert pytc.is_tree_equal(t.at[0].apply(lambda _: 10), Test(10))
+    assert pytc.is_tree_equal(t.at[1].at[0].apply(lambda _: 100), Test(1, l0(100)))
+
+
 def test_mixed_get():
     @pytc.treeclass
     class l0:
@@ -454,8 +505,8 @@ def test_mixed_get():
         b: l0 = l0()
 
     t = Test()
-    assert pytc.is_tree_equal(t.at["b"].at[t == 2].get(), Test(None, l0(2, None)))
-    assert pytc.is_tree_equal(t.at[t == 2].at["b"].get(), Test(None, l0(2, None)))
+    assert pytc.is_tree_equal(t.at[1].at[t == 2].get(), Test(None, l0(2, None)))
+    assert pytc.is_tree_equal(t.at[t == 2].at[1].get(), Test(None, l0(2, None)))
 
 
 def test_mixed_set():
@@ -473,6 +524,10 @@ def test_mixed_set():
 
     assert pytc.is_tree_equal(t.at["b"].at[t == 2].set(100), Test(1, l0(100, 2)))
     assert pytc.is_tree_equal(t.at[t == 2].at["b"].set(100), Test(1, l0(100, 2)))
+    assert pytc.is_tree_equal(t.at[1].at[t == 2].set(100), Test(1, l0(100, 2)))
+    assert pytc.is_tree_equal(t.at[t == 2].at[1].set(100), Test(1, l0(100, 2)))
+    assert pytc.is_tree_equal(t.at["b"].at[0].set(100), Test(1, l0(100, 2)))
+    assert pytc.is_tree_equal(t.at[0].at["b"].set(100), Test(1, l0(100, 2)))
 
 
 def test_mixed_apply():
@@ -494,6 +549,13 @@ def test_mixed_apply():
     assert pytc.is_tree_equal(
         t.at[t == 2].at["a"].apply(lambda _: 100), Test(1, l0(100))
     )
+
+    assert pytc.is_tree_equal(
+        t.at[1].at[t == 2].apply(lambda _: 100), Test(1, l0(100, 2))
+    )
+    assert pytc.is_tree_equal(t.at[t == 2].at[0].apply(lambda _: 100), Test(1, l0(100)))
+    assert pytc.is_tree_equal(t.at["b"].at[0].apply(lambda _: 100), Test(1, l0(100, 2)))
+    assert pytc.is_tree_equal(t.at[0].at["a"].apply(lambda _: 100), Test(1, l0(100)))
 
 
 def test_method_call():
@@ -556,11 +618,10 @@ def test_repr_str():
 
     t = Test()
 
-    assert repr(t.at["a"]) == "TreeAtName(tree=Test(a=1, b=2), where=('a',))"
-    assert str(t.at["a"]) == "TreeAtName(tree=Test(a=1, b=2), where=('a',))"
+    assert repr(t.at["a"]) == "TreeAtPath(tree=Test(a=1, b=2), where=('a',))"
+    assert str(t.at["a"]) == "TreeAtPath(tree=Test(a=1, b=2), where=('a',))"
     assert (
-        repr(t.at[...])
-        == "TreeAtPyTree(tree=Test(a=1, b=2), where=Test(a=True, b=True))"
+        repr(t.at[...]) == "TreeAtMask(tree=Test(a=1, b=2), where=Test(a=True, b=True))"
     )
 
 

--- a/tests/test_tree_freeze.py
+++ b/tests/test_tree_freeze.py
@@ -107,8 +107,7 @@ def test_freeze_errors():
     with pytest.raises(TypeError):
         t.at[...].apply(jnp.sin)
 
-    with pytest.raises(TypeError):
-        t.at[...].reduce(jnp.sin)
+    t.at[...].reduce(jnp.sin)
 
 
 def test_freeze_with_ops():
@@ -151,7 +150,7 @@ def test_freeze_with_ops():
 
     assert pytc.is_tree_equal(t.at[...].set(0), t)
     assert pytc.is_tree_equal(t.at[...].apply(lambda x: x + 1), t)
-    assert pytc.is_tree_equal(t.at[...].reduce(jnp.sin), 0.0)
+    assert pytc.is_tree_equal(t.at[...].reduce(jnp.sin, initializer=0), 0.0)
 
     @pytc.treeclass
     class Test:


### PR DESCRIPTION
**The new `tree_trace` registry-based functionality enables indexing by node key or index.**
This PR adds  
1- integer indexing  `tree.at[0].{get,set,apply,reduce}`
2- composability of boolean mask indexing with path indexing `tree.at[tree>1].at['a'].{get,set,apply,reduce}`

The name and indexing rules can be registered using the following pattern.

```python

# sample code to define  trace func flatten rule  for a certain class
# that is used with `tree_summary`, `tree_diagram`, `tree_mermaid` and indexing with `.at`

from pytreeclass._src.tree_trace import LeafTrace, register_pytree_node_trace

def _dict_trace_func(tree: dict) -> Sequence[LeafTrace]:
    names = ([f"['{k}']"] for k in tree)
    types = ([type(tree[key])] for key in tree)
    index = ([i] for i in range(len(tree)))
    width = ([len(tree)] for _ in range(len(tree)))
    metas = ([k.startswith("_")] for k in tree)  # omits keys starting with `_`
    return [LeafTrace(*x) for x in zip(names, types, index, width, metas)]

register_pytree_node_trace(dict, _dict_trace_func)
```

Next, it can be used with `.at`  method in `PyTreeClass`

### Example code

```python
import pytreeclass as pytc 

@pytc.treeclass
class L0:
    g: int = 1
    h: int = 2
    i: int = 3

@pytc.treeclass
class L1:
    d: L0 = L0()
    e: int =4
    f: int =5

@pytc.treeclass
class L2:
    a: L1 = L1()
    b: int =6
    c: int =7

tree = L2()
# L2
#     ├── a:L1
#     │   ├── d:L0
#     │   │   ├── g=1
#     │   │   ├── h=2
#     │   │   └── i=3
#     │   ├── e=4
#     │   └── f=5
#     ├── b=6
#     └── c=7

tree.at[0].get()  
# L2(a=L1(d=L0(g=1, h=2, i=3), e=4, f=5), b=None, c=None)

tree.at[0].at[0].get() 
# L2(a=L1(d=L0(g=1, h=2, i=3), e=None, f=None), b=None, c=None)

tree.at[0].at[0].at[0].get() 
# L2(a=L1(d=L0(g=1, h=None, i=None), e=None, f=None), b=None, c=None)


# mix index and key 

tree.at['a'].get()  
# L2(a=L1(d=L0(g=1, h=2, i=3), e=4, f=5), b=None, c=None)

tree.at['a'].at[0].get() 
# L2(a=L1(d=L0(g=1, h=2, i=3), e=None, f=None), b=None, c=None)

tree.at[0].at['d'].at[0].get() 
# L2(a=L1(d=L0(g=1, h=None, i=None), e=None, f=None), b=None, c=None)
```



