### PR TITLE
Faster trace

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: "${{ matrix.os }}"
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install jaxlib
+          python -m pip install jaxlib==0.4.4
           python -m pip install pytest pytest-benchmark wheel optax coverage
       - name: Pytest Check
         run: |

--- a/pytreeclass/__init__.py
+++ b/pytreeclass/__init__.py
@@ -42,4 +42,4 @@ __all__ = (
     "tree_indexer",
 )
 
-__version__ = "0.2.0b7"
+__version__ = "0.2.0b8"

--- a/pytreeclass/_src/tree_base.py
+++ b/pytreeclass/_src/tree_base.py
@@ -24,7 +24,7 @@ from pytreeclass._src.tree_decorator import (
 from pytreeclass._src.tree_freeze import _tree_hash, _tree_unwrap
 from pytreeclass._src.tree_indexer import _tree_copy, bcmap, tree_indexer
 from pytreeclass._src.tree_pprint import tree_repr, tree_str
-from pytreeclass._src.tree_trace import LeafTrace, register_pytree_node_trace
+from pytreeclass._src.tree_trace import register_pytree_node_trace
 
 PyTree = Any
 
@@ -48,7 +48,7 @@ def _tree_flatten(tree: PyTree) -> tuple[list[Any], tuple[list[str], dict[str, A
     return dynamic.values(), (dynamic.keys(), static)
 
 
-def _tree_trace(tree: PyTree) -> Sequence[LeafTrace]:
+def _tree_trace(tree: PyTree) -> Sequence[Sequence[str, type, int, int, Any]]:
     """Trace flatten rule to be used with the `tree_trace` module"""
     leaves, (keys, _) = _tree_flatten(tree)
     names = (f"{key}" for key in keys)


### PR DESCRIPTION
Improved performance in tracing, affects any operation using `tree_map_with_trace`

New registering format (i.e. no need to wrap it with a `LeafTrace` object)

```python

def _dict_trace_func(tree: dict) :
    names = (f"['{k}']" for k in tree)
    types = (type(tree[key]) for key in tree)
    index = range(len(tree))
    width = (len(tree) for _ in range(len(tree)))
    metas = ({"repr": not k.startswith("_")} for k in tree)
    return [*zip(names, types, index, width, metas)]

```