### PR TITLE
add `tree_repr_with_trace`

### DIFF
--- a/docs/API/base.rst
+++ b/docs/API/base.rst
@@ -15,6 +15,7 @@ Public API
     tree_repr
     tree_str
     tree_summary
+    tree_repr_with_trace
     is_nondiff
     is_frozen
     unfreeze
@@ -48,6 +49,7 @@ Pretty Printing API
 .. autofunction:: tree_repr 
 .. autofunction:: tree_str
 .. autofunction:: tree_summary
+.. autofunction:: tree_repr_with_trace
 
 Wrapping and freezing API
 -------------------

--- a/pytreeclass/__init__.py
+++ b/pytreeclass/__init__.py
@@ -12,6 +12,7 @@ from pytreeclass._src.tree_pprint import (
     tree_diagram,
     tree_mermaid,
     tree_repr,
+    tree_repr_with_trace,
     tree_str,
     tree_summary,
 )
@@ -35,6 +36,7 @@ __all__ = (
     "tree_repr",
     "tree_str",
     "tree_summary",
+    "tree_trace_summary",
     # freeze/unfreeze utils
     "is_nondiff",
     "is_frozen",

--- a/pytreeclass/_src/tree_pprint.py
+++ b/pytreeclass/_src/tree_pprint.py
@@ -878,13 +878,14 @@ def tree_repr_with_trace(tree: PyTree) -> PyTree:
     """Return a PyTree with the same structure, but with the leaves replaced by a summary of the trace.
 
     Example:
+        >>> import pytreeclass as pytc
         >>> @pytc.treeclass
         ... class Test:
         ...    a:int = 1
         ...    b:float = 2.0
 
         >>> tree = Test()
-        >>> print(tree_repr_with_trace(Test()))
+        >>> print(pytc.tree_repr_with_trace(Test()))
         Test(
         a=
             ┌──────────┬─────────┐

--- a/tests/test_tree_pprint.py
+++ b/tests/test_tree_pprint.py
@@ -278,3 +278,17 @@ def test_invalid_depth():
         tree_summary(1, depth="a")
     with pytest.raises(TypeError):
         tree_mermaid(1, depth="a")
+
+
+def test_tree_repr_with_trace():
+    @pytc.treeclass
+    class Test:
+        a: int = 1
+        b: float = 2.0
+
+    tree = Test()
+    assert (
+        str(pytc.tree_repr_with_trace(Test()))
+        # trunk-ignore(flake8/E501)
+        == "Test(\n  a=\n    ┌──────────┬─────────┐\n    │value     │1        │\n    ├──────────┼─────────┤\n    │name path │Test->a  │\n    ├──────────┼─────────┤\n    │type path │Test->int│\n    ├──────────┼─────────┤\n    │index path│0->0     │\n    └──────────┴─────────┘, \n  b=\n    ┌──────────┬───────────┐\n    │value     │2.0        │\n    ├──────────┼───────────┤\n    │name path │Test->b    │\n    ├──────────┼───────────┤\n    │type path │Test->float│\n    ├──────────┼───────────┤\n    │index path│0->1       │\n    └──────────┴───────────┘\n)"
+    )


### PR DESCRIPTION
We are getting more pretty 🤩 


```python
>>> @pytc.treeclass
... class Test:
...    a:int = 1
...    b:float = 2.0

>>> tree = Test()
>>> print(tree_repr_with_trace(Test()))
Test(
a=
    ┌──────────┬─────────┐
    │value     │1        │
    ├──────────┼─────────┤
    │name path │Test->a  │
    ├──────────┼─────────┤
    │type path │Test->int│
    ├──────────┼─────────┤
    │index path│0->0     │
    └──────────┴─────────┘,
b=
    ┌──────────┬───────────┐
    │value     │2.0        │
    ├──────────┼───────────┤
    │name path │Test->b    │
    ├──────────┼───────────┤
    │type path │Test->float│
    ├──────────┼───────────┤
    │index path│0->1       │
    └──────────┴───────────┘
)

```