### PR TITLE
add `alias` in `Field`

### DIFF
--- a/tests/test_treeclass.py
+++ b/tests/test_treeclass.py
@@ -109,6 +109,15 @@ def test_field():
         Test()
 
 
+def test_field_alias():
+    @pytc.treeclass
+    class Tree:
+        _name: str = pytc.field(alias="name")
+
+    tree = Tree(name="test")
+    assert tree._name == "test"
+
+
 def test_field_nondiff():
     @ft.partial(pytc.treeclass, leafwise=True)
     class Test:

--- a/tests/test_treeclass.py
+++ b/tests/test_treeclass.py
@@ -117,6 +117,13 @@ def test_field_alias():
     tree = Tree(name="test")
     assert tree._name == "test"
 
+    with pytest.raises(TypeError):
+        pytc.field(alias=1)
+
+
+def test_field_hash():
+    hash(pytc.field(default=1)) == hash(pytc.field(default=1))
+
 
 def test_field_nondiff():
     @ft.partial(pytc.treeclass, leafwise=True)


### PR DESCRIPTION
Ref:
[1] https://www.attrs.org/en/stable/init.html#private-attributes-and-aliases
[2] https://discuss.python.org/t/add-alias-as-a-field-parameter-for-dataclasses/22988
[3] https://docs.python.org/3/library/typing.html?highlight=dataclass_transform#typing.dataclass_transform