### PR TITLE
use instance variable

### DIFF
--- a/pytreeclass/__init__.py
+++ b/pytreeclass/__init__.py
@@ -54,4 +54,4 @@ __all__ = (
     "tree_repr_with_trace",
 )
 
-__version__ = "0.2.5"
+__version__ = "0.2.6"

--- a/pytreeclass/_src/tree_indexer.py
+++ b/pytreeclass/_src/tree_indexer.py
@@ -617,7 +617,7 @@ def _swop(func):
     return ft.wraps(func)(lambda lhs, rhs: func(rhs, lhs))
 
 
-def _leafwise_transform(klass: T) -> T:
+def _leafwise_transform(klass: type[T]) -> type[T]:
     # add leafwise transform methods to the class
     # that enable the user to apply a function to
     # all the leaves of the tree

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -5,6 +5,7 @@ import functools as ft
 import jax
 import jax.numpy as jnp
 import jax.tree_util as jtu
+import numpy.testing as npt
 import pytest
 
 import pytreeclass as pytc
@@ -352,15 +353,19 @@ def test_reduce_and_its_derivatives():
             lambda x, y: jnp.minimum(x, jnp.min(y)), initializer=jnp.inf
         )
     ) == 0.98507565
-    assert (
+    npt.assert_allclose(
         tree.at[tree > 0].reduce(
             lambda x, y: jnp.maximum(x, jnp.max(y)), initializer=-jnp.inf
-        )
-    ) == 1.3969219
-    assert (
-        tree.at[tree > 0].reduce(lambda x, y: x + jnp.sum(y), initializer=0)
-    ) == 10.6970625
-    assert (tree.at[tree > 0].reduce(lambda x, y: x * jnp.product(y), initializer=1)) == 1.8088213  # fmt: skip
+        ),
+        1.3969219,
+    )
+    npt.assert_allclose(
+        tree.at[tree > 0].reduce(lambda x, y: x + jnp.sum(y), initializer=0), 10.6970625
+    )
+    npt.assert_allclose(
+        tree.at[tree > 0].reduce(lambda x, y: x * jnp.product(y), initializer=1),
+        1.8088213,
+    )
 
 
 def test_is_leaf():


### PR DESCRIPTION
This PR enables adding `Field` to instance variables of `treeclass` wrapped classes after initialization using `.at` functionality.
Example, in torch we can do the following:
```python
import torch 


class Tree(torch.nn.Module):
    def __init__(self, bias):
        super().__init__()
        self.bias = torch.nn.Parameter(torch.tensor(bias))

tree = Tree(0.)
tree.weight = torch.nn.Parameter(torch.tensor(3.))
list(tree.parameters())
# [Parameter containing:
#  tensor(0., requires_grad=True),
#  Parameter containing:
#  tensor(3., requires_grad=True)]
```

Torch overrides `setattr` to recognize values of `Parameter` and`Module` type to register them as model parameters.
The examples show the ability to add parameters not defined in the init method; instead, it's being added after initialization.

Since `PyTreeClass` wrapped classes are immutable by default, setting an attribute after initialization is only possible using the `.at` functionality. `.at` creates a new instance with the updated value. However, in pytreeclass,  fields (I.e. class parameters) are tied to the class, not the instance. This means no field can be added after initialization through the `.at` method. This PR adds this functionality, which is demonstrated in the following example:

```python

import pytreeclass as pytc
from typing import Any

@pytc.treeclass
class Parameter:
    value: Any

@pytc.treeclass
class Tree:
    bias : int = 0 

    def add_param(self, name, param):
        return setattr(self, name, param)

tree = Tree()

_, tree_with_weight_param = tree.at['add_param']('weight', Parameter(3))

print(tree)
# Tree(bias=0)

print(tree_with_weight_param)
# Tree(bias=0, weight=Parameter(value=3))

```

