### PR TITLE
Deprecate autounwrapping in favaor of Freeze/unfreeze pattern

### DIFF
--- a/docs/API/base.rst
+++ b/docs/API/base.rst
@@ -62,7 +62,6 @@ Wrapping and freezing API
 .. autofunction:: is_frozen
 .. autofunction:: freeze
 .. autofunction:: unfreeze
-.. autoclass:: ImmutableWrapper
 
 
 Advanced API

--- a/pytreeclass/__init__.py
+++ b/pytreeclass/__init__.py
@@ -54,4 +54,4 @@ __all__ = (
     "tree_repr_with_trace",
 )
 
-__version__ = "0.2.6"
+__version__ = "0.2.7"

--- a/pytreeclass/__init__.py
+++ b/pytreeclass/__init__.py
@@ -1,11 +1,5 @@
 from pytreeclass._src.tree_decorator import field, fields, is_treeclass, treeclass
-from pytreeclass._src.tree_freeze import (
-    ImmutableWrapper,
-    freeze,
-    is_frozen,
-    is_nondiff,
-    unfreeze,
-)
+from pytreeclass._src.tree_freeze import freeze, is_frozen, is_nondiff, unfreeze
 from pytreeclass._src.tree_indexer import bcmap, is_tree_equal, tree_indexer
 from pytreeclass._src.tree_pprint import (
     tree_diagram,
@@ -43,7 +37,6 @@ __all__ = (
     "is_frozen",
     "freeze",
     "unfreeze",
-    "ImmutableWrapper",
     # masking and indexing utils
     "bcmap",
     "tree_indexer",

--- a/pytreeclass/_src/tree_decorator.py
+++ b/pytreeclass/_src/tree_decorator.py
@@ -56,6 +56,9 @@ class Field(NamedTuple):
     def __hash__(self) -> int:
         return tree_hash(self)
 
+    def __repr__(self) -> str:
+        return tree_repr(self)
+
 
 def field(
     *,
@@ -196,7 +199,7 @@ def _generate_field_map(klass: type) -> dict[str, Field]:
     for name in (annotation_map := vars(klass)[_ANNOTATIONS]):
         # get the value associated with the type hint
         # in essence will skip any non type-hinted attributes
-        value = getattr(klass, name, _NOT_SET)
+        value = vars(klass).get(name, _NOT_SET)
         # at this point we stick to the type hint provided by the user
         # inconsistency between the type hint and the value will be handled later
         type = annotation_map[name]

--- a/pytreeclass/_src/tree_decorator.py
+++ b/pytreeclass/_src/tree_decorator.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, NamedTuple, Sequence, TypeVar
 import jax.tree_util as jtu
 from typing_extensions import dataclass_transform
 
-from pytreeclass._src.tree_freeze import ImmutableWrapper, tree_hash
+from pytreeclass._src.tree_freeze import tree_hash
 from pytreeclass._src.tree_indexer import (
     _conditional_mutable_method,
     _leafwise_transform,
@@ -429,17 +429,6 @@ def _register_treeclass(klass: type[T]) -> type[T]:
         jtu.register_pytree_node(klass, _tree_flatten, ft.partial(_tree_unflatten, klass))  # type: ignore
 
     return klass
-
-
-def _tree_unwrap(value: Any) -> Any:
-    # enables the transparent wrapper behavior iniside `treeclass` wrapped classes
-    def is_leaf(x: Any) -> bool:
-        return isinstance(x, ImmutableWrapper) or is_treeclass(x)
-
-    def unwrap(value: Any) -> Any:
-        return value.unwrap() if isinstance(value, ImmutableWrapper) else value
-
-    return jtu.tree_map(unwrap, value, is_leaf=is_leaf)
 
 
 def _init_subclass_wrapper(init_subclass_method: Callable) -> Callable:

--- a/pytreeclass/_src/tree_pprint.py
+++ b/pytreeclass/_src/tree_pprint.py
@@ -234,7 +234,8 @@ def _namedtuple_pprint(
         kvs = node._asdict().items()
         fmt = (f"{k}={_node_pprint(v,indent+1,kind,width,depth-1)}" for k, v in kvs)
         fmt = (", \n" + "\t" * (indent + 1)).join(fmt)
-    fmt = "namedtuple(\n" + "\t" * (indent + 1) + (fmt) + "\n" + "\t" * (indent) + ")"
+    name = type(node).__name__
+    fmt = f"{name}(\n" + "\t" * (indent + 1) + (fmt) + "\n" + "\t" * (indent) + ")"
     return _format_width(fmt, width)
 
 

--- a/pytreeclass/_src/tree_trace.py
+++ b/pytreeclass/_src/tree_trace.py
@@ -94,8 +94,7 @@ def register_pytree_node_trace(
     """
     Args:
         klass: The class of the object to be traced.
-        trace_func:
-            A function that takes an instance of type `klass` and defines the flatten rule
+        trace_func:A function that takes an instance of type `klass` and defines the flatten rule
             for the object (name, type, index, metadata) for each leaf in the object.
 
     Example:

--- a/tests/test_tree_freeze.py
+++ b/tests/test_tree_freeze.py
@@ -359,6 +359,7 @@ def test_freeze_nondiff_func():
 
     @jax.value_and_grad
     def loss_func(model):
+        model = model.at[...].apply(pytc.unfreeze, is_leaf=pytc.is_frozen)
         return jnp.mean((model(1.0) - 0.5) ** 2)
 
     @jax.jit

--- a/tests/test_tree_pprint.py
+++ b/tests/test_tree_pprint.py
@@ -56,13 +56,13 @@ def test_repr():
     assert (
         tree_repr(r1)
         # trunk-ignore(flake8/E501)
-        == "Repr1(\n  a=1, \n  b='string', \n  c=1.0, \n  d='aaaaa', \n  e=[10, 10, 10, 10, 10], \n  f={1, 2, 3}, \n  g={\n    a:'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', \n    b:'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', \n    c:f32[5,5](μ=1.00, σ=0.00, ∈[1.00,1.00])\n  }, \n  h=f32[5,1](μ=1.00, σ=0.00, ∈[1.00,1.00]), \n  i=f32[1,6](μ=1.00, σ=0.00, ∈[1.00,1.00]), \n  j=f32[1,1,4,5](μ=1.00, σ=0.00, ∈[1.00,1.00]), \n  l=namedtuple(b=1, c=2), \n  m=f32[5,5](μ=1.00, σ=0.00, ∈[1.00,1.00]), \n  n=bool[0], \n  o=c64[2]\n)"
+        == "Repr1(\n  a=1, \n  b='string', \n  c=1.0, \n  d='aaaaa', \n  e=[10, 10, 10, 10, 10], \n  f={1, 2, 3}, \n  g={\n    a:'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', \n    b:'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb', \n    c:f32[5,5](μ=1.00, σ=0.00, ∈[1.00,1.00])\n  }, \n  h=f32[5,1](μ=1.00, σ=0.00, ∈[1.00,1.00]), \n  i=f32[1,6](μ=1.00, σ=0.00, ∈[1.00,1.00]), \n  j=f32[1,1,4,5](μ=1.00, σ=0.00, ∈[1.00,1.00]), \n  l=a(b=1, c=2), \n  m=f32[5,5](μ=1.00, σ=0.00, ∈[1.00,1.00]), \n  n=bool[0], \n  o=c64[2]\n)"
     )
 
     assert (
         tree_repr(r1, depth=1)
         # trunk-ignore(flake8/E501)
-        == "Repr1(\n  a=1, \n  b='string', \n  c=1.0, \n  d='aaaaa', \n  e=[...], \n  f={...}, \n  g={...}, \n  h=f32[5,1](μ=1.00, σ=0.00, ∈[1.00,1.00]), \n  i=f32[1,6](μ=1.00, σ=0.00, ∈[1.00,1.00]), \n  j=f32[1,1,4,5](μ=1.00, σ=0.00, ∈[1.00,1.00]), \n  l=namedtuple(...), \n  m=f32[5,5](μ=1.00, σ=0.00, ∈[1.00,1.00]), \n  n=bool[0], \n  o=c64[2]\n)"
+        == "Repr1(\n  a=1, \n  b='string', \n  c=1.0, \n  d='aaaaa', \n  e=[...], \n  f={...}, \n  g={...}, \n  h=f32[5,1](μ=1.00, σ=0.00, ∈[1.00,1.00]), \n  i=f32[1,6](μ=1.00, σ=0.00, ∈[1.00,1.00]), \n  j=f32[1,1,4,5](μ=1.00, σ=0.00, ∈[1.00,1.00]), \n  l=a(...), \n  m=f32[5,5](μ=1.00, σ=0.00, ∈[1.00,1.00]), \n  n=bool[0], \n  o=c64[2]\n)"
     )
 
     assert tree_repr(r1, depth=0) == "Repr1(...)"
@@ -72,13 +72,13 @@ def test_str():
     assert (
         tree_str(r1)
         # trunk-ignore(flake8/E501)
-        == "Repr1(\n  a=1, \n  b=string, \n  c=1.0, \n  d=aaaaa, \n  e=[10, 10, 10, 10, 10], \n  f={1, 2, 3}, \n  g={\n    a:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, \n    b:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, \n    c:\n      [[1. 1. 1. 1. 1.]\n       [1. 1. 1. 1. 1.]\n       [1. 1. 1. 1. 1.]\n       [1. 1. 1. 1. 1.]\n       [1. 1. 1. 1. 1.]]\n  }, \n  h=[[1.] [1.] [1.] [1.] [1.]], \n  i=[[1. 1. 1. 1. 1. 1.]], \n  j=[[[[1. 1. 1. 1. 1.]   [1. 1. 1. 1. 1.]   [1. 1. 1. 1. 1.]   [1. 1. 1. 1. 1.]]]], \n  l=namedtuple(b=1, c=2), \n  m=\n    [[1. 1. 1. 1. 1.]\n     [1. 1. 1. 1. 1.]\n     [1. 1. 1. 1. 1.]\n     [1. 1. 1. 1. 1.]\n     [1. 1. 1. 1. 1.]], \n  n=True, \n  o=[1.+0.j 2.+0.j]\n)"
+        == "Repr1(\n  a=1, \n  b=string, \n  c=1.0, \n  d=aaaaa, \n  e=[10, 10, 10, 10, 10], \n  f={1, 2, 3}, \n  g={\n    a:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa, \n    b:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb, \n    c:\n      [[1. 1. 1. 1. 1.]\n       [1. 1. 1. 1. 1.]\n       [1. 1. 1. 1. 1.]\n       [1. 1. 1. 1. 1.]\n       [1. 1. 1. 1. 1.]]\n  }, \n  h=[[1.] [1.] [1.] [1.] [1.]], \n  i=[[1. 1. 1. 1. 1. 1.]], \n  j=[[[[1. 1. 1. 1. 1.]   [1. 1. 1. 1. 1.]   [1. 1. 1. 1. 1.]   [1. 1. 1. 1. 1.]]]], \n  l=a(b=1, c=2), \n  m=\n    [[1. 1. 1. 1. 1.]\n     [1. 1. 1. 1. 1.]\n     [1. 1. 1. 1. 1.]\n     [1. 1. 1. 1. 1.]\n     [1. 1. 1. 1. 1.]], \n  n=True, \n  o=[1.+0.j 2.+0.j]\n)"
     )
 
     assert (
         tree_str(r1, depth=1)
         # trunk-ignore(flake8/E501)
-        == "Repr1(\n  a=1, \n  b=string, \n  c=1.0, \n  d=aaaaa, \n  e=[...], \n  f={...}, \n  g={...}, \n  h=[[1.] [1.] [1.] [1.] [1.]], \n  i=[[1. 1. 1. 1. 1. 1.]], \n  j=[[[[1. 1. 1. 1. 1.]   [1. 1. 1. 1. 1.]   [1. 1. 1. 1. 1.]   [1. 1. 1. 1. 1.]]]], \n  l=namedtuple(...), \n  m=\n    [[1. 1. 1. 1. 1.]\n     [1. 1. 1. 1. 1.]\n     [1. 1. 1. 1. 1.]\n     [1. 1. 1. 1. 1.]\n     [1. 1. 1. 1. 1.]], \n  n=True, \n  o=[1.+0.j 2.+0.j]\n)"
+        == "Repr1(\n  a=1, \n  b=string, \n  c=1.0, \n  d=aaaaa, \n  e=[...], \n  f={...}, \n  g={...}, \n  h=[[1.] [1.] [1.] [1.] [1.]], \n  i=[[1. 1. 1. 1. 1. 1.]], \n  j=[[[[1. 1. 1. 1. 1.]   [1. 1. 1. 1. 1.]   [1. 1. 1. 1. 1.]   [1. 1. 1. 1. 1.]]]], \n  l=a(...), \n  m=\n    [[1. 1. 1. 1. 1.]\n     [1. 1. 1. 1. 1.]\n     [1. 1. 1. 1. 1.]\n     [1. 1. 1. 1. 1.]\n     [1. 1. 1. 1. 1.]], \n  n=True, \n  o=[1.+0.j 2.+0.j]\n)"
     )
 
 
@@ -110,7 +110,7 @@ def test_tree_diagram():
     assert tree_diagram(r1, depth=0) == tree_indent(r1, depth=0) == "Repr1"
 
     # trunk-ignore(flake8/E501)
-    out = "Repr1\n├── a=1\n├── b='string'\n├── c=1.0\n├── d='aaaaa'\n├── e=[...]\n├── f={...}\n├── g={...}\n├── h=f32[5,1](μ=1.00, σ=0.00, ∈[1.00,1.00])\n├── i=f32[1,6](μ=1.00, σ=0.00, ∈[1.00,1.00])\n├── j=f32[1,1,4,5](μ=1.00, σ=0.00, ∈[1.00,1.00])\n├── k=(...)\n├── l=namedtuple(...)\n├── m=f32[5,5](μ=1.00, σ=0.00, ∈[1.00,1.00])\n├── n=bool[0]\n└── o=c64[2]"
+    out = "Repr1\n├── a=1\n├── b='string'\n├── c=1.0\n├── d='aaaaa'\n├── e=[...]\n├── f={...}\n├── g={...}\n├── h=f32[5,1](μ=1.00, σ=0.00, ∈[1.00,1.00])\n├── i=f32[1,6](μ=1.00, σ=0.00, ∈[1.00,1.00])\n├── j=f32[1,1,4,5](μ=1.00, σ=0.00, ∈[1.00,1.00])\n├── k=(...)\n├── l=a(...)\n├── m=f32[5,5](μ=1.00, σ=0.00, ∈[1.00,1.00])\n├── n=bool[0]\n└── o=c64[2]"
 
     assert tree_diagram(r1, depth=1) == out
     assert tree_indent(r1, depth=1) == _tree_to_indent(out)
@@ -151,7 +151,7 @@ def test_tree_mermaid():
     assert (
         tree_mermaid(r1, depth=1)
         # trunk-ignore(flake8/E501)
-        == 'flowchart LR\n    id0(<b>Repr1</b>)\n    id0 --- id1("</b>a=1</b>")\n    id0 --- id2("</b>b=\'string\'</b>")\n    id0 --- id3("</b>c=1.0</b>")\n    id0 --- id4("</b>d=\'aaaaa\'</b>")\n    id0 --- id5("</b>e=[...]</b>")\n    id0 --- id6("</b>f={...}</b>")\n    id0 --- id7("</b>g={...}</b>")\n    id0 --- id8("</b>h=f32[5,1](μ=1.00, σ=0.00, ∈[1.00,1.00])</b>")\n    id0 --- id9("</b>i=f32[1,6](μ=1.00, σ=0.00, ∈[1.00,1.00])</b>")\n    id0 --- id10("</b>j=f32[1,1,4,5](μ=1.00, σ=0.00, ∈[1.00,1.00])</b>")\n    id0 --- id11("</b>k=(...)</b>")\n    id0 --- id12("</b>l=namedtuple(...)</b>")\n    id0 --- id13("</b>m=f32[5,5](μ=1.00, σ=0.00, ∈[1.00,1.00])</b>")\n    id0 --- id14("</b>n=bool[0]</b>")\n    id0 --- id15("</b>o=c64[2]</b>")\n'
+        == 'flowchart LR\n    id0(<b>Repr1</b>)\n    id0 --- id1("</b>a=1</b>")\n    id0 --- id2("</b>b=\'string\'</b>")\n    id0 --- id3("</b>c=1.0</b>")\n    id0 --- id4("</b>d=\'aaaaa\'</b>")\n    id0 --- id5("</b>e=[...]</b>")\n    id0 --- id6("</b>f={...}</b>")\n    id0 --- id7("</b>g={...}</b>")\n    id0 --- id8("</b>h=f32[5,1](μ=1.00, σ=0.00, ∈[1.00,1.00])</b>")\n    id0 --- id9("</b>i=f32[1,6](μ=1.00, σ=0.00, ∈[1.00,1.00])</b>")\n    id0 --- id10("</b>j=f32[1,1,4,5](μ=1.00, σ=0.00, ∈[1.00,1.00])</b>")\n    id0 --- id11("</b>k=(...)</b>")\n    id0 --- id12("</b>l=a(...)</b>")\n    id0 --- id13("</b>m=f32[5,5](μ=1.00, σ=0.00, ∈[1.00,1.00])</b>")\n    id0 --- id14("</b>n=bool[0]</b>")\n    id0 --- id15("</b>o=c64[2]</b>")\n'
     )
     assert (
         tree_mermaid(r1, depth=2)

--- a/tests/test_treeclass.py
+++ b/tests/test_treeclass.py
@@ -482,7 +482,7 @@ def test_treeclass_frozen_field():
 
     t = Test(1)
 
-    assert t.a == 1
+    assert t.a == pytc.freeze(1)
     assert jtu.tree_leaves(t) == []
 
 

--- a/tests/test_under_jit.py
+++ b/tests/test_under_jit.py
@@ -52,6 +52,7 @@ def test_jit_freeze():
 
     @jax.value_and_grad
     def loss_func(model, x, y):
+        model = model.at[...].apply(pytc.unfreeze, is_leaf=pytc.is_frozen)
         return jnp.mean((model(x) - y) ** 2)
 
     @jax.jit


### PR DESCRIPTION
This PR deprecates the auto unwrapping of frozen instances inside `treeclass.`
The motivation is to unify the training pattern of `treeclass` with any arbitrary pytrees.

Using `freeze/unfreeze` does not require splitting/partitioning the tree; instead, the `freeze` wraps the leaf with a registered Wrapper that yields no leaves (i.e. shields the wrapped subtree from any changes). 
This pattern is preferable to `split/partition.` 
 - as it avoids creating extra tree as
 - avoid changing the loss function signature to allow for the extra tree as an argument.


To pass a tree to `jax` transformation, use the `freeze/unfreeze` pattern:

```python

import jax 
import pytreeclass as pytc

tree = [1, 2., 3.]  

@jax.jit
@jax.grad 
def F(x):
    # unfreeze the tree
    x = jax.tree_map(pytc.unfreeze, x, is_leaf=pytc.is_frozen)
    return sum(x)


try:
    F(tree)  # <--- this will fail
except TypeError as e:
    print(e)


# freeze int to allow passing the tree to jax transformations
jaxable_tree = [pytc.freeze(1), 2., 3.]

print(F(jaxable_tree))  # <--- this will work
# [#1, Array(1., dtype=float32, weak_type=True), Array(1., dtype=float32, weak_type=True)]

```

