### PR TITLE
all instance variables are leaves

### DIFF
--- a/pytreeclass/__init__.py
+++ b/pytreeclass/__init__.py
@@ -43,4 +43,4 @@ __all__ = (
     "tree_repr_with_trace",
 )
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/pytreeclass/_src/__init__.py
+++ b/pytreeclass/_src/__init__.py
@@ -1,0 +1,3 @@
+from .tree_decorator import build_field_map
+
+__all__ = ["build_field_map"]

--- a/pytreeclass/_src/tree_pprint.py
+++ b/pytreeclass/_src/tree_pprint.py
@@ -17,6 +17,7 @@ from jax.util import unzip2
 from jaxlib.xla_extension import PjitFunction
 
 import pytreeclass as pytc
+import pytreeclass._src as src
 
 PyTree = Any
 PrintKind = Literal["repr", "str"]
@@ -271,7 +272,8 @@ def _treeclass_pprint(
         fmt = "..."
 
     else:
-        kvs = ((k, vars(node)[k]) for k, f in node._fields.items() if f.repr)
+        skip = [k for k, f in src.build_field_map(type(node)).items() if not f.repr]
+        kvs = ((k, v) for k, v in vars(node).items() if k not in skip)
         fmt = (f"{k}={_node_pprint(v,indent+1,kind,width,depth-1)}" for k, v in kvs)
         fmt = (", \n" + "\t" * (indent + 1)).join(fmt)
     fmt = f"{name}(\n" + "\t" * (indent + 1) + (fmt) + "\n" + "\t" * (indent) + ")"

--- a/tests/test_treeclass.py
+++ b/tests/test_treeclass.py
@@ -11,13 +11,6 @@ from jax import numpy as jnp
 import pytreeclass as pytc
 
 
-def test_field_metadata():
-    class Test(pytc.TreeClass, leafwise=True):
-        a: int = pytc.field(default=1, metadata={"a": 1})
-
-    assert Test()._fields["a"].metadata["a"] == 1
-
-
 def test_field_mutually_exclusive():
     with pytest.raises(ValueError):
         pytc.field(default=1, factory=lambda: 1)
@@ -189,7 +182,7 @@ def test_subclassing():
 
     l1 = L1()
 
-    assert jtu.tree_leaves(l1) == [2, 4, 5]
+    assert jtu.tree_leaves(l1) == [2, 4, 5, 5]
     assert l1.inc(10) == 20
     assert l1.sub(10) == 0
     assert l1.d == 5
@@ -539,10 +532,8 @@ def test_instance_field_map():
 
     _, tree_with_weight = tree.at["add_param"]("weight", Parameter(3))
 
-    assert tree._fields != tree_with_weight._fields
     assert tree_with_weight.weight == Parameter(3)
     assert "weight" not in vars(tree)
-    assert "weight" not in tree._fields
 
 
 def test_field_factory():


### PR DESCRIPTION
All instance variables are leaves

Motivation:
- This change enables `.at` to work on all instance variables