### PR TITLE
Annotated callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,35 +516,46 @@ print(counter.calls) # 10
 
 ## ➕ More<a id="more"></a>
 
-<details> <summary>Validate or convert inputs using callbacks</summary>
+<details> <summary>Validate or convert inputs using type hints</summary>
 
-`PyTreeClass` includes `callbacks` in the `field` to apply a sequence of functions on input at setting the attribute stage. The callback is quite useful in several cases, for instance, to ensure a certain input type within a valid range. See example:
+`PyTreeClass` executes functions defined inside `typing.Annotated` on field values before assigning it to the instance.
+The functionality can be quite useful in several cases, for instance, to ensure a certain input type within a valid range. See example:
 
 ```python
 import jax
 import pytreeclass as pytc
+# python 3.9+
+from typing import Annotated
 
-def positive_int_callback(value):
-    if not isinstance(value, int):
-        raise TypeError("Value must be an integer")
-    if value <= 0:
-        raise ValueError("Value must be positive")
-    return value
+class PositiveInt:
+    def __call__(self,value):
+        if not isinstance(value, int):
+            raise TypeError("Value must be an integer")
+        if value <= 0:
+            raise ValueError("Value must be positive")
+        return value
 
 
 class Tree(pytc.TreeClass):
-    in_features:int = pytc.field(callbacks=[positive_int_callback])
+    in_features:Annotated[int, PositiveInt()]
+    # in_features:int = pytc.field(callbacks=[positive_int_callback])
 
 
 tree = Tree(1)
 # no error
 
-tree = Tree(0)
-# ValueError: Error for field=`in_features`:
+try:
+    tree = Tree(0)
+except ValueError as e:
+    print(e)
+# Error for field=`in_features`:
 # Value must be positive
 
-tree = Tree(1.0)
-# TypeError: Error for field=`in_features`:
+try:
+    tree = Tree(1.0)
+except TypeError as e:
+    print(e)
+# Error for field=`in_features`:
 # Value must be an integer
 ```
 

--- a/README.md
+++ b/README.md
@@ -524,8 +524,10 @@ The functionality can be quite useful in several cases, for instance, to ensure 
 ```python
 import jax
 import pytreeclass as pytc
-# python 3.9+
+# python 3.9 and above
 from typing import Annotated
+# python 3.8
+# from typing_extensions import Annotated
 
 class PositiveInt:
     def __call__(self,value):
@@ -537,9 +539,7 @@ class PositiveInt:
 
 
 class Tree(pytc.TreeClass):
-    in_features:Annotated[int, PositiveInt()]
-    # in_features:int = pytc.field(callbacks=[positive_int_callback])
-
+    in_features: Annotated[int, PositiveInt()]
 
 tree = Tree(1)
 # no error

--- a/pytreeclass/__init__.py
+++ b/pytreeclass/__init__.py
@@ -50,4 +50,4 @@ __all__ = (
     "Partial",
 )
 
-__version__ = "0.3.4"
+__version__ = "0.3.5"

--- a/tests/test_treeclass.py
+++ b/tests/test_treeclass.py
@@ -7,6 +7,7 @@ import jax.tree_util as jtu
 import numpy.testing as npt
 import pytest
 from jax import numpy as jnp
+from typing_extensions import Annotated
 
 import pytreeclass as pytc
 
@@ -369,7 +370,7 @@ def test_callbacks():
         return _range_validator
 
     class Test(pytc.TreeClass):
-        a: int = pytc.field(callbacks=[instance_validator(int)])
+        a: Annotated[int, instance_validator(int)]
 
     with pytest.raises(AssertionError):
         Test(a="a")
@@ -377,7 +378,7 @@ def test_callbacks():
     assert Test(a=1).a == 1
 
     class Test(pytc.TreeClass):
-        a: int = pytc.field(callbacks=[instance_validator((int, float))])
+        a: Annotated[int, instance_validator((int, float))]
 
     assert Test(a=1).a == 1
     assert Test(a=1.0).a == 1.0
@@ -386,7 +387,7 @@ def test_callbacks():
         Test(a="a")
 
     class Test(pytc.TreeClass):
-        a: int = pytc.field(callbacks=[range_validator(0, 10)])
+        a: Annotated[int, range_validator(0, 10)]
 
     with pytest.raises(AssertionError):
         Test(a=-1)
@@ -397,7 +398,7 @@ def test_callbacks():
         Test(a=11)
 
     class Test(pytc.TreeClass):
-        a: int = pytc.field(callbacks=[range_validator(0, 10), instance_validator(int)])
+        a: Annotated[int, range_validator(0, 10), instance_validator(int)]
 
     with pytest.raises(AssertionError):
         Test(a=-1)
@@ -408,24 +409,14 @@ def test_callbacks():
     with pytest.raises(TypeError):
 
         class Test(pytc.TreeClass):
-            a: int = pytc.field(callbacks=1)
-
-    with pytest.raises(TypeError):
-
-        class Test(pytc.TreeClass):
-            a: int = pytc.field(callbacks=[1])
-
-    with pytest.raises(TypeError):
-
-        class Test(pytc.TreeClass):
-            a: int = pytc.field(callbacks=[lambda: True])
+            a: Annotated[int, lambda: True]
 
         Test(a=1)
 
 
 def test_treeclass_frozen_field():
     class Test(pytc.TreeClass):
-        a: int = pytc.field(callbacks=[pytc.freeze])
+        a: Annotated[int, pytc.freeze]
 
     t = Test(1)
 


### PR DESCRIPTION
move callbacks to inside `typing.Annotated`
instead of `field(...callbacks=[...])` use `field_name: Annotated[type, *callbacks]`. 
check [PEP 593](https://peps.python.org/pep-0593) and https://github.com/annotated-types/annotated-types for motivation.

```python
import jax
import pytreeclass as pytc
# python 3.9 and above
from typing import Annotated
# python 3.8
# from typing_extensions import Annotated

class PositiveInt:
    def __call__(self,value):
        if not isinstance(value, int):
            raise TypeError("Value must be an integer")
        if value <= 0:
            raise ValueError("Value must be positive")
        return value


class Tree(pytc.TreeClass):
    in_features: Annotated[int, PositiveInt()]

tree = Tree(1)
# no error

try:
    tree = Tree(0)
except ValueError as e:
    print(e)
# Error for field=`in_features`:
# Value must be positive

try:
    tree = Tree(1.0)
except TypeError as e:
    print(e)
# Error for field=`in_features`:
# Value must be an integer

```