### PR TITLE
Field edits

### DIFF
--- a/pytreeclass/__init__.py
+++ b/pytreeclass/__init__.py
@@ -1,4 +1,4 @@
-from pytreeclass._src.code_build import field, fields
+from pytreeclass._src.code_build import KW_ONLY, POS_ONLY, field, fields
 from pytreeclass._src.tree_base import AtIndexer, TreeClass
 from pytreeclass._src.tree_pprint import (
     tree_diagram,
@@ -28,6 +28,8 @@ __all__ = (
     "is_tree_equal",
     "field",
     "fields",
+    "KW_ONLY",
+    "POS_ONLY",
     # pprint utils
     "tree_diagram",
     "tree_mermaid",

--- a/pytreeclass/_src/code_build.py
+++ b/pytreeclass/_src/code_build.py
@@ -61,6 +61,30 @@ def field(
             initialization to modify the field value.
         alias: An a alias for the field name in the constructor.
 
+    Note:
+        - use `pytreeclass.POS_ONLY` and `pytreeclass.KW_ONLY` to mark
+            positional-only and keyword-only arguments in the constructor.
+            for example::
+
+                >>> import pytreeclass as pytc
+                >>> class Tree(pytc.TreeClass):
+                ...     x: int = pytc.field(default=0)
+                ...     # positional only field for all fields before it
+                ...     _: pytc.POS_ONLY
+                ...     # keyword only field for all fields after it
+                ...     __: pytc.KW_ONLY
+                ...     y: int = pytc.field(default=0)
+
+        - The `callbacks` are called in the order they are provided, and
+            each callback must be a one-argument function operating on the field
+        - The `alias` is used to rename the field in the constructor, and
+            it must be a string describing the alias name of the field in the
+        constructor or `None` if no alias is provided.
+        - The `metadata` is a dictionary describing the metadata of the field
+            or `None` if no metadata is provided.
+        - The `default` is the default value of the field, and it must be
+            non-mutable types.
+
     Example:
         >>> import pytreeclass as pytc
         >>> class IsInstance(pytc.TreeClass):

--- a/pytreeclass/_src/code_build.py
+++ b/pytreeclass/_src/code_build.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-import dataclasses as dc
 import functools as ft
 import sys
 from collections.abc import Callable, MutableMapping, MutableSequence
@@ -28,8 +27,8 @@ EllipsisType = type(Ellipsis)
 _NOT_SET = type("NOT_SET", (), {"__repr__": lambda _: "NOT_SET"})()
 _MUTABLE_TYPES = (MutableSequence, MutableMapping, set)
 # https://github.com/google/jax/issues/14295
-KW_ONLY = dc.KW_ONLY  # get the hint support
-POS_ONLY = type("_POS_ONLY_TYPE", (), {})()
+KW_ONLY = type("_KW_ONLY_TYPE", (), {"__repr__": lambda _: "*"})()
+POS_ONLY = type("_POS_ONLY_TYPE", (), {"__repr__": lambda _: "/"})()
 
 
 class Field(NamedTuple):
@@ -44,8 +43,8 @@ class Field(NamedTuple):
 
 
 def field(
-    *,
     default: Any = _NOT_SET,
+    *,
     init: bool = True,
     repr: bool = True,
     metadata: dict[str, Any] | None = None,  # type: ignore

--- a/pytreeclass/_src/tree_base.py
+++ b/pytreeclass/_src/tree_base.py
@@ -26,6 +26,8 @@ import numpy as np
 from typing_extensions import dataclass_transform
 
 from pytreeclass._src.code_build import (
+    KW_ONLY,
+    POS_ONLY,
     Field,
     _build_field_map,
     _build_init_method,
@@ -338,7 +340,11 @@ class TreeClassMeta(abc.ABCMeta):
             # throwing an `AttributeError`
             getattr(klass, "__init__")(self, *a, **k)
 
-        if len(keys := set(_build_field_map(klass)) - set(vars(self))):
+        if keys := [
+            k
+            for k, f in _build_field_map(klass).items()
+            if k not in vars(self) and f.type not in (KW_ONLY, POS_ONLY)
+        ]:
             raise AttributeError(f"Found uninitialized fields {keys}.")
         return self
 

--- a/tests/test_treeclass.py
+++ b/tests/test_treeclass.py
@@ -11,14 +11,6 @@ from jax import numpy as jnp
 import pytreeclass as pytc
 
 
-def test_field_mutually_exclusive():
-    with pytest.raises(ValueError):
-        pytc.field(default=1, factory=lambda: 1)
-
-    with pytest.raises(ValueError):
-        pytc.field(default=1, pos_only=True, kw_only=True)
-
-
 def test_fields():
     class Test(pytc.TreeClass):
         a: int = pytc.field(default=1, metadata={"meta": 1})
@@ -35,26 +27,43 @@ def test_field():
         pytc.field(metadata=1)
 
     class Test(pytc.TreeClass):
-        a: int = pytc.field(default=1, pos_only=True)
+        a: int = pytc.field(default=1)
+        _: pytc.POS_ONLY
         b: int = 2
 
     with pytest.raises(TypeError):
         # positonal only for a
         Test(a=1, b=2)
 
+    with pytest.raises(ValueError):
+
+        class Test(pytc.TreeClass):
+            a: int = pytc.field(default=1)
+            _: pytc.POS_ONLY
+            __: pytc.POS_ONLY
+
+    with pytest.raises(ValueError):
+
+        class Test(pytc.TreeClass):
+            a: int = pytc.field(default=1)
+            _: pytc.KW_ONLY
+            __: pytc.KW_ONLY
+
     assert Test(1, b=2).a == 1
     assert Test(1, 2).b == 2
 
     class Test(pytc.TreeClass):
-        a: int = pytc.field(default=1, pos_only=True)
-        b: int = pytc.field(default=2, pos_only=True)
+        a: int = pytc.field(default=1)
+        b: int = pytc.field(default=2)
+        _: pytc.POS_ONLY
 
     assert Test(1, 2).a == 1
     assert Test(1, 2).b == 2
 
     # keyword only
     class Test(pytc.TreeClass):
-        a: int = pytc.field(default=1, kw_only=True)
+        _: pytc.KW_ONLY
+        a: int = pytc.field(default=1)
         b: int = 2
 
     with pytest.raises(TypeError):
@@ -66,8 +75,10 @@ def test_field():
     assert Test(a=1, b=2).a == 1
 
     class Test(pytc.TreeClass):
-        a: int = pytc.field(default=1, pos_only=True)
-        b: int = pytc.field(default=2, kw_only=True)
+        a: int = pytc.field(default=1)
+        _: pytc.POS_ONLY
+        __: pytc.KW_ONLY
+        b: int = pytc.field(default=2)
 
     with pytest.raises(TypeError):
         Test(1, 2)
@@ -79,7 +90,8 @@ def test_field():
 
     # test when init is False
     class Test(pytc.TreeClass):
-        a: int = pytc.field(default=1, init=False, kw_only=True)
+        _: pytc.KW_ONLY
+        a: int = pytc.field(default=1, init=False)
         b: int = 2
 
     with pytest.raises(TypeError):
@@ -89,7 +101,6 @@ def test_field():
 
     class Test(pytc.TreeClass):
         a: int = pytc.field(default=1)
-        b: int = pytc.field(factory=lambda: 1)
 
         def __init__(self) -> None:
             pass
@@ -537,10 +548,3 @@ def test_instance_field_map():
 
     assert tree_with_weight.weight == Parameter(3)
     assert "weight" not in vars(tree)
-
-
-def test_field_factory():
-    class Tree(pytc.TreeClass):
-        a: int = pytc.field(factory=lambda: 1)
-
-    assert Tree().a == 1


### PR DESCRIPTION
This PR changes the way to define keyword-only or positional only arguments and remove factory for mutable types.


- add `KW_ONLY` and `POS_ONLY`

```python
>>> import pytreeclass as pytc
>>> class Tree(pytc.TreeClass):
...     x: int = pytc.field(default=0)
...     # positional only field for all fields before it
...     _: pytc.POS_ONLY
...     # keyword only field for all fields after it
...     __: pytc.KW_ONLY
...     y: int = pytc.field(default=0)
```

- remove `field(..., factory=)` and raise an error for mutable types
-  remove `field(..., kw_only=)` and `field(..., pos_only=)` use the above method instead.