### PR TITLE
add at.scan for map with state functionality

### DIFF
--- a/docs/API/base.rst
+++ b/docs/API/base.rst
@@ -77,6 +77,7 @@ Advanced API
         get,
         set,
         apply,
+        scan,
         __call__,
 .. autoclass:: RegexKey
     :members:

--- a/docs/notebooks/common_recipes.ipynb
+++ b/docs/notebooks/common_recipes.ipynb
@@ -965,13 +965,6 @@
     "tree = tree.at[positive_mask].at[weight_mask].apply(lambda x: x**2)\n",
     "print(tree)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/pytreeclass/_src/tree_base.py
+++ b/pytreeclass/_src/tree_base.py
@@ -257,7 +257,10 @@ class AtIndexer(NamedTuple):
             func: the function to apply to the leaf values. the function accepts
                 a leaf value and a state and returns a tuple of the new leaf
                 value and updated state.
-            is_leaf: a predicate function to determine if a value is a leaf.
+            state: the initial state to carry.
+            is_leaf: a predicate function to determine if a value is a leaf. for
+                example, `lambda x: isinstance(x, list)` will treat all lists
+                as leaves and will not recurse into list items.
 
         Returns:
             A tuple of a PyTree with the leaf values at the specified location

--- a/pytreeclass/_src/tree_util.py
+++ b/pytreeclass/_src/tree_util.py
@@ -118,7 +118,6 @@ class IntKey(BaseKey):
         return self.idx == other
 
     @__eq__.register(jtu.SequenceKey)
-    @__eq__.register(NamedSequenceKey)
     def _(self, other) -> bool:
         return self.idx == other.idx
 
@@ -139,7 +138,6 @@ class NameKey(BaseKey):
         return self.name == other
 
     @__eq__.register(jtu.GetAttrKey)
-    @__eq__.register(NamedSequenceKey)
     def _(self, other) -> bool:
         return self.name == other.name
 
@@ -202,7 +200,6 @@ class RegexKey(BaseKey):
         return re.fullmatch(self.pattern, other) is not None
 
     @__eq__.register(jtu.GetAttrKey)
-    @__eq__.register(NamedSequenceKey)
     def _(self, other) -> bool:
         return re.fullmatch(self.pattern, other.name) is not None
 

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -760,3 +760,20 @@ def test_multi_key():
         tree.at["a"].set(100).at["b"].set(100),
         tree.at["a", "b"].set(100),
     )
+
+
+def test_scan():
+    class Tree(pytc.TreeClass):
+        a: int = 1
+        b: int = 2
+        c: int = 3
+
+    tree = Tree()
+
+    def func_with_state(x, state):
+        return x + 1, state + 1
+
+    tree, state = tree.at["a", "b"].scan(func_with_state, state=1)
+
+    assert pytc.is_tree_equal(tree, Tree(a=2, b=3, c=3))
+    assert state == 3


### PR DESCRIPTION

This PR adds `.at.scan(func,state)`  to apply func to pytree leaves while carrying state.
The following example showcases this functionality

```python
import pytreeclass as pytc
from typing import NamedTuple

class State(NamedTuple):
    func_evals: int = 0

class Tree(pytc.TreeClass):
    a: int
    b: int
    c: int

tree = Tree(a=1, b=2, c=3)

def scan_func(leaf, state: State):
    state = State(state.func_evals + 1)
    return leaf + 1, state

# apply to `a` and `b` and return a new instance with all other
# leaves unchanged and the new state that counts the number of
# function evaluations
tree.at['a','b'].scan(scan_func, state=State())
# (Tree(a=2, b=3, c=3), State(func_evals=2))
```