### PR TITLE
Nested mutations using .at['method_key']

### DIFF
--- a/pytreeclass/_src/tree_base.py
+++ b/pytreeclass/_src/tree_base.py
@@ -209,7 +209,7 @@ class TreeClass(metaclass=TreeClassMeta):
         getattr(object, "__setattr__")(self, key, value)
 
     def __delattr__(self, key: str) -> None:
-        if id(getattr(self, key)) not in _mutable_instance_registry:
+        if id(self) not in _mutable_instance_registry:
             # instance is not under a mutable context
             raise AttributeError(
                 f"Cannot delete attribute `{key}` "

--- a/tests/test_treeclass.py
+++ b/tests/test_treeclass.py
@@ -617,5 +617,11 @@ def test_nested_mutation():
         def ff(self):
             return self.inner.f()
 
+        def df(self):
+            del self.inner.a
+
     _, v = OuterModule().at["ff"]()
     assert v.inner.a == 2
+
+    _, v = OuterModule().at["df"]()
+    assert "a" not in v.inner.__dict__

--- a/tests/test_treeclass.py
+++ b/tests/test_treeclass.py
@@ -599,3 +599,23 @@ def test_init_subclass():
         ...
 
     assert Test2.hello == 1
+
+
+def test_nested_mutation():
+    @pytc.autoinit
+    class InnerModule(pytc.TreeClass):
+        a: int = 1
+
+        def f(self):
+            self.a += 1
+            return self.a
+
+    @pytc.autoinit
+    class OuterModule(pytc.TreeClass):
+        inner: InnerModule = InnerModule()
+
+        def ff(self):
+            return self.inner.f()
+
+    _, v = OuterModule().at["ff"]()
+    assert v.inner.a == 2


### PR DESCRIPTION
Motivation:

Experiment with lazy initialization, where inner modules initialize their params based on input.

Example

```python
import pytreeclass as pytc
import jax.random as jr
from typing import Any
import jax
import jax.numpy as jnp


@pytc.autoinit
class LazyLinear(pytc.TreeClass):
    out_features: int

    def param(self, name: str, value: Any):
        if name not in vars(self):
            setattr(self, name, value)
        return vars(self)[name]

    def __call__(self, x: jax.Array, *, key: jr.KeyArray = jr.PRNGKey(0)):
        in_features = self.param("in_features", x.shape[-1])
        weight = self.param("weight", jnp.ones((in_features, self.out_features)))
        bias = self.param("bias", jnp.zeros((self.out_features,)))
        return x @ weight + bias


@pytc.autoinit
class StackedLinear(pytc.TreeClass):
    l1: LazyLinear = LazyLinear(10)
    l2: LazyLinear = LazyLinear(10)

    def call(self, x: jax.Array):
        return self.l2(self.l1(x))

l = StackedLinear()
print(repr(l))
# StackedLinear(l1=LazyLinear(out_features=10), l2=LazyLinear(out_features=10))


_, ll = l.at["call"](jnp.ones((1, 5)))
ll
# StackedLinear(
#   l1=LazyLinear(
#     out_features=10, 
#     in_features=5, 
#     weight=f32[5,10](μ=1.00, σ=0.00, ∈[1.00,1.00]), 
#     bias=f32[10](μ=0.00, σ=0.00, ∈[0.00,0.00])
#   ), 
#   l2=LazyLinear(
#     out_features=10, 
#     in_features=10, 
#     weight=f32[10,10](μ=1.00, σ=0.00, ∈[1.00,1.00]), 
#     bias=f32[10](μ=0.00, σ=0.00, ∈[0.00,0.00])
#   )
# )
```

