### PR TITLE
On getattr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ _These changes enable:_
 
 1) stricter data validation on instance values, as in the following example:
 
+    <details> 
+
     `on_setattr` ensure the value is of certain type (e.g.integer) during _initialization_, and `on_getattr`, ensure the value is of certain type (e.g. integer) whenever its accessed.
 
 
@@ -41,7 +43,11 @@ _These changes enable:_
     tree(1.0)  # AssertionError: must be an int
     ```
 
+    </details>
+
 2) Frozen field without using `tree_mask`/`tree_unmask`
+
+    <details>
 
     The following shows a pattern where the value is frozen on `__setattr__` and unfrozen whenever accessed, this ensures that `jax` transformation does not see the value. the following example showcase this functionality
 
@@ -70,7 +76,12 @@ _These changes enable:_
 
     Compared with other libraies that implements `static_field`, this pattern has *lower* overhead and does not alter `tree_flatten`/`tree_unflatten` methods of the tree.
 
+
+    </details>
+
 3) Easier way to create a buffer (non-trainable array)
+
+    <details>
 
     Just use `jax.lax.stop_gradient` in `on_getattr`
 
@@ -98,6 +109,8 @@ _These changes enable:_
     f(tree, 1.0)  # Array([1., 2., 3.], dtype=float32)
     print(jax.grad(f)(tree, 1.0))  # Tree(buffer=[0. 0. 0.])
     ```
+
+    </details>
 
 ## v0.7
 

--- a/docs/notebooks/common_recipes.ipynb
+++ b/docs/notebooks/common_recipes.ipynb
@@ -241,7 +241,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## [5] Using `callbacks` to validate/convert inputs"
+    "## [5] Using `on_setattr` to validate/convert inputs"
    ]
   },
   {
@@ -297,7 +297,7 @@
     "@pytc.autoinit\n",
     "class Foo(pytc.TreeClass):\n",
     "    # allow in_dim to be an integer between [1,100]\n",
-    "    in_dim: int = pytc.field(callbacks=[IsInstance(int), Range(1, 100)])\n",
+    "    in_dim: int = pytc.field(on_setattr=[IsInstance(int), Range(1, 100)])\n",
     "\n",
     "\n",
     "tree = Foo(1)\n",
@@ -424,7 +424,7 @@
     "\n",
     "@pytc.autoinit\n",
     "class Tree(pytc.TreeClass):\n",
-    "    array: jax.Array = pytc.field(callbacks=[validator, converter])\n",
+    "    array: jax.Array = pytc.field(on_setattr=[validator, converter])\n",
     "\n",
     "\n",
     "x = jnp.ones([3, 1, 2, 6])\n",
@@ -506,7 +506,7 @@
     "# lets fix this by freezing the dropout rate\n",
     "@pytc.autoinit\n",
     "class Dropout(pytc.TreeClass):\n",
-    "    drop_rate: float = pytc.field(callbacks=[pytc.freeze], default=0.0)\n",
+    "    drop_rate: float = pytc.field(on_setattr=[pytc.freeze], default=0.0)\n",
     "\n",
     "    def __call__(self, x, *, key):\n",
     "        keep_rate = 1.0 - self.drop_rate\n",

--- a/pytreeclass/__init__.py
+++ b/pytreeclass/__init__.py
@@ -76,7 +76,7 @@ __all__ = (
     "leafwise",
 )
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 
 AtIndexer.__module__ = "pytreeclass"
 TreeClass.__module__ = "pytreeclass"

--- a/pytreeclass/_src/tree_base.py
+++ b/pytreeclass/_src/tree_base.py
@@ -111,30 +111,11 @@ class TreeClassMeta(abc.ABCMeta):
 class TreeClass(metaclass=TreeClassMeta):
     """Convert a class to a ``jax``-compatible pytree by inheriting from :class:`.TreeClass`.
 
-    - A pytree is any nested structure that can be used with ``jax`` functions.
-      A pytree can be a container or a leaf. Container examples are: a ``tuple``,
-      ``list``, or ``dict``. A leaf is a non-container data structure like an
-      ``int``, ``float``, ``string``, or ``jax.Array``. Examples of pytrees are:
-
-      >>> tree = [1, "string", 2.]  # 3 leaves and 1 container (list) # doctest: +SKIP
-      list
-      ├── [0]=1
-      ├── [1]=string
-      └── [2]=2.0
-
-      >>> tree = [dict(a=1, b=2), (1, 2, 3)]  # 5 leaves and 3 containers (list, dict, tuple) # doctest: +SKIP
-      list
-      ├── [0]:dict
-      │   ├── ['a']=1
-      │   └── ['b']=2
-      └── [1]:tuple
-          ├── [0]=1
-          ├── [1]=2
-          └── [2]=3
-
-    - :class:`.TreeClass` is a container pytree that holds other pytrees in
-      its attributes.
-
+    A pytree is any nested structure that can be used with ``jax`` functions.
+    A pytree can be a container or a leaf. Container examples are: a ``tuple``,
+    ``list``, or ``dict``. A leaf is a non-container data structure like an
+    ``int``, ``float``, ``string``, or ``jax.Array``. :class:`.TreeClass` is a
+    container pytree that holds other pytrees in its attributes.
 
     Note:
         ``pytreeclass`` offers two methods to define the ``__init__`` method:

--- a/pytreeclass/_src/tree_index.py
+++ b/pytreeclass/_src/tree_index.py
@@ -574,7 +574,7 @@ class AtIndexer(NamedTuple):
         *,
         is_leaf: IsLeafType = None,
     ) -> tuple[PyTree, S]:
-        """Apply a function with carrtying a state.
+        """Apply a function while carrying a state.
 
         Args:
             func: the function to apply to the leaf values. the function accepts


### PR DESCRIPTION
### Additions:
- Add `on_getattr` in `field` to apply function on `__getattr__`

### Breaking changes:
- Rename `callbacks` in `field` to `on_setattr` to match `attrs` and better reflect its functionality.



_These changes enable:_

1) stricter data validation on instance values, as in the following example:

    <details> 

    `on_setattr` ensure the value is of certain type (e.g.integer) during _initialization_, and `on_getattr`, ensure the value is of certain type (e.g. integer) whenever its accessed.


    ```python

    import pytreeclass as pytc
    import jax

    def assert_int(x):
        assert isinstance(x, int), "must be an int"
        return x

    @pytc.autoinit
    class Tree(pytc.TreeClass):
        a: int = pytc.field(on_getattr=[assert_int], on_setattr=[assert_int])

        def __call__(self, x):
            # enusre `a` is an int before using it in computation by calling `assert_int`
            a: int = self.a
            return a + x

    tree = Tree(a=1)
    print(tree(1.0))  # 2.0
    tree = jax.tree_map(lambda x: x + 0.0, tree)  # make `a` a float
    tree(1.0)  # AssertionError: must be an int
    ```

    </details>

2) Frozen field without using `tree_mask`/`tree_unmask`

    <details>

    The following shows a pattern where the value is frozen on `__setattr__` and unfrozen whenever accessed, this ensures that `jax` transformation does not see the value. the following example showcase this functionality

    ```python
    import pytreeclass as pytc
    import jax

    @pytc.autoinit
    class Tree(pytc.TreeClass):
        frozen_a : int = pytc.field(on_getattr=[pytc.unfreeze], on_setattr=[pytc.freeze])

        def __call__(self, x):
            return self.frozen_a + x

    tree = Tree(frozen_a=1)  # 1 is non-jaxtype
    # can be used in jax transformations

    @jax.jit
    def f(tree, x):
        return tree(x)

    f(tree, 1.0)  # 2.0

    grads = jax.grad(f)(tree, 1.0)  # Tree(frozen_a=#1)
    ```

    Compared with other libraies that implements `static_field`, this pattern has *lower* overhead and does not alter `tree_flatten`/`tree_unflatten` methods of the tree.


    </details>

3) Easier way to create a buffer (non-trainable array)

    <details>

    Just use `jax.lax.stop_gradient` in `on_getattr`

    ```python
    import pytreeclass as pytc
    import jax
    import jax.numpy as jnp

    def assert_array(x):
        assert isinstance(x, jax.Array)
        return x

    @pytc.autoinit
    class Tree(pytc.TreeClass):
        buffer: jax.Array = pytc.field(on_getattr=[jax.lax.stop_gradient],on_setattr=[assert_array])
        def __call__(self, x):
            return self.buffer**x
        
    tree = Tree(buffer=jnp.array([1.0, 2.0, 3.0]))
    tree(2.0)  # Array([1., 4., 9.], dtype=float32)
    @jax.jit
    def f(tree, x):
        return jnp.sum(tree(x))

    f(tree, 1.0)  # Array([1., 2., 3.], dtype=float32)
    print(jax.grad(f)(tree, 1.0))  # Tree(buffer=[0. 0. 0.])
    ```

    </details>