### PR TITLE
Added polymorphism to AtIndexer

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -12,7 +12,7 @@ pandoc>=2.3
 pygments>=2.14.0
 sphinx-book-theme>=1.0.0
 sphinx-autodoc-typehints>=1.22
-sphinx>=6.1.3
+sphinx==7.2.6
 # sphinxcontrib-bibtex>=2.5.0
 sphinxcontrib-katex>=0.9.4
 typing-extensions>=4.5.0

--- a/pytreeclass/_src/backend/treelib/optree.py
+++ b/pytreeclass/_src/backend/treelib/optree.py
@@ -125,11 +125,16 @@ class OpTreeTreeLib(AbstractTreeLib):
             entries = tuple(NamedSequenceKey(*ik) for ik in enumerate(keys))
             return (tuple(dynamic.values()), keys, entries)
 
-        ot.register_pytree_node(klass, flatten, unflatten, namespace)
+        ot.register_pytree_node(klass, flatten, unflatten, namespace=namespace)
 
     @staticmethod
     def register_static(klass: type[Tree]) -> None:
-        ot.register_pytree_node(klass, lambda x: ((), x), lambda x, _: x, namespace)
+        ot.register_pytree_node(
+            klass,
+            lambda x: ((), x),
+            lambda x, _: x,
+            namespace=namespace,
+        )
 
     @staticmethod
     def attribute_key(name: str) -> GetAttrKey:

--- a/pytreeclass/_src/tree_index.py
+++ b/pytreeclass/_src/tree_index.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 import abc
 import functools as ft
 import re
-from typing import Any, Callable, Hashable, NamedTuple, Tuple, TypeVar
+from typing import Any, Callable, Hashable, NamedTuple, Tuple, TypeVar, Generic
 
 from pytreeclass._src.backend import arraylib, treelib
 from pytreeclass._src.backend.treelib.base import ParallelConfig
@@ -398,8 +398,8 @@ def _resolve_where(
 
     return mask
 
-
-class AtIndexer(NamedTuple):
+TIndexer = TypeVar('TIndexer', bound='AtIndexer')
+class AtIndexer(NamedTuple, Generic[TIndexer]):
     """Index a pytree at a given path using a path or mask.
 
     Args:
@@ -458,7 +458,7 @@ class AtIndexer(NamedTuple):
     tree: PyTree
     where: tuple[BaseKey | PyTree] | tuple[()] = ()
 
-    def __getitem__(self, where: Any) -> AtIndexer:
+    def __getitem__(self, where: Any) -> TIndexer:
         # AtIndexer[where] will extend the current path with `where`
         # for example AtIndexer[where1][where2] will extend the current path
         # with `where1` and `where2` to indicate the path to the leaves to

--- a/pytreeclass/_src/tree_index.py
+++ b/pytreeclass/_src/tree_index.py
@@ -31,7 +31,8 @@ from __future__ import annotations
 import abc
 import functools as ft
 import re
-from typing import Any, Callable, Hashable, NamedTuple, Tuple, TypeVar, Self
+from typing import Any, Callable, Hashable, NamedTuple, Tuple, TypeVar
+from typing_extensions import Self
 
 from pytreeclass._src.backend import arraylib, treelib
 from pytreeclass._src.backend.treelib.base import ParallelConfig

--- a/pytreeclass/_src/tree_index.py
+++ b/pytreeclass/_src/tree_index.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 import abc
 import functools as ft
 import re
-from typing import Any, Callable, Hashable, NamedTuple, Tuple, TypeVar, Generic
+from typing import Any, Callable, Hashable, NamedTuple, Tuple, TypeVar, Self
 
 from pytreeclass._src.backend import arraylib, treelib
 from pytreeclass._src.backend.treelib.base import ParallelConfig
@@ -398,8 +398,8 @@ def _resolve_where(
 
     return mask
 
-TIndexer = TypeVar('TIndexer', bound='AtIndexer')
-class AtIndexer(NamedTuple, Generic[TIndexer]):
+
+class AtIndexer(NamedTuple):
     """Index a pytree at a given path using a path or mask.
 
     Args:
@@ -458,7 +458,7 @@ class AtIndexer(NamedTuple, Generic[TIndexer]):
     tree: PyTree
     where: tuple[BaseKey | PyTree] | tuple[()] = ()
 
-    def __getitem__(self, where: Any) -> TIndexer:
+    def __getitem__(self, where: Any) -> Self:
         # AtIndexer[where] will extend the current path with `where`
         # for example AtIndexer[where1][where2] will extend the current path
         # with `where1` and `where2` to indicate the path to the leaves to

--- a/pytreeclass/_src/tree_pprint.py
+++ b/pytreeclass/_src/tree_pprint.py
@@ -603,25 +603,6 @@ def tree_summary(
         ├────┼────┼─────┼─────┤
         │Σ   │int │1    │4.00B│
         └────┴────┴─────┴─────┘
-
-    Example:
-        >>> # set custom type display for jaxprs
-        >>> import jax
-        >>> import pytreeclass as tc
-        >>> ClosedJaxprType = type(jax.make_jaxpr(lambda x: x)(1))
-        >>> @tc.tree_summary.def_type(ClosedJaxprType)
-        ... def _(expr: ClosedJaxprType) -> str:
-        ...     jaxpr = expr.jaxpr
-        ...     return f"Jaxpr({jaxpr.invars}, {jaxpr.outvars})"
-        >>> def func(x, y):
-        ...     return x
-        >>> jaxpr = jax.make_jaxpr(func)(1, 2)
-        >>> print(tc.tree_summary(jaxpr))
-        ┌────┬──────────────────┬─────┬────┐
-        │Name│Type              │Count│Size│
-        ├────┼──────────────────┼─────┼────┤
-        │Σ   │Jaxpr([a, b], [a])│1    │    │
-        └────┴──────────────────┴─────┴────┘
     """
     rows = [["Name", "Type", "Count", "Size"]]
     tcount = tsize = 0


### PR DESCRIPTION
Hi,
I love your work on the pytreeclass and find it very useful. In this pull request, I added a proper type hint to the AtIndexer \_\_get_item\_\_ function. When using subclasses of Atindexer,  type checking tools like Pylance understand that the function actually returns the subclass and not an AtIndexer, even though the inherited function is called. 
Yannik